### PR TITLE
Disable auditing on `npm install`-like commands

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+audit=false
 lockfile-version=2


### PR DESCRIPTION
Relates to #18

Update the npm configuration to disable outputting an audit report when running commands like `npm install`. As this project uses [better-npm-audit](https://github.com/jeemok/better-npm-audit#readme), the output of `npm audit` can be a bit too noisy for what this project needs.

Configuration is based on https://docs.npmjs.com/cli/v8/using-npm/config