### PR TITLE
Remove SAST from the nightly CI workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,11 +17,3 @@ jobs:
           - v0
     with:
       ref: ${{ matrix.ref }}
-  sast:
-    name: SAST
-    uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-sast.yml@main
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      ref: main


### PR DESCRIPTION
### Summary

Don't run the reusable SAST workflow in the nightly workflow. The motivation being that, with pinned Action versions and a SAST scan on all pushes to the `main` branch anyway, analyzing the `main` branch nightly does not add any value.

Additionally, the nightly run can cause interference with CodeQL because it expects an analysis coming from the nightly workflow on the Pull Request branch if the base happened to be the subject of a nightly scan. Examples:

- https://github.com/ericcornelissen/eslint-plugin-top/pull/25/checks?check_run_id=8577048788
- https://github.com/ericcornelissen/eslint-plugin-top/pull/27/checks?check_run_id=8588905309