### PR TITLE
Use Fossa CLI to check licenses

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,15 @@
+# Check out Fossa at: https://fossa.com/
+
+version: 3
+
+server: https://app.fossa.com
+
+project:
+  id: github.com/ericcornelissen/eslint-plugin-top
+  name: eslint-plugin-top
+  url: https://github.com/ericcornelissen/eslint-plugin-top
+
+paths:
+  exclude:
+    - ./_reports/
+    - ./.temp/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,6 +59,19 @@ jobs:
         run: npm ci
       - name: Check formatting
         run: npm run lint
+  licenses:
+    name: Licenses
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Install Fossa CLI
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+      - name: Check licenses
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        run: npm run check-licenses
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "_prettier": "prettier ./**/*.{js,json,md,ts,yml} --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
     "build": "rollup --config rollup.config.ts",
+    "check-licenses": "fossa analyze && fossa test",
     "clean": "git clean -fqX .temp/ _reports/ index.js",
     "coverage": "c8 --reporter=lcov --reporter=text --reports-dir=_reports/coverage npm run test",
     "format": "npm run _prettier -- --write",


### PR DESCRIPTION
Relates to #23

---

### Summary

Add a [Fossa] configuration file and an npm script to check the licenses of the dependencies of the project using the [Fossa CLI] (doing this locally still requires a Fossa account, including an API key, though). Also use the npm script in the CI to continuously check the licenses for any potential problems.

The project currently uses the Fossa GitHub integration, this setup allows for more easily reproducing the license check locally. Also, using the [Fossa CLI] allows for using a configuration file, being added here as well.

[fossa]: https://fossa.com/
[fossa cli]: https://github.com/fossas/fossa-cli