### PR TITLE
Fix npm auditing in the (reusable) audit workflow

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Audit all npm dependencies
-        if: ${{ !startsWith(inputs.ref, 'v') }}
+        if: ${{ !startsWith(matrix.ref, 'v') }}
         run: npm run audit
       - name: Audit production npm dependencies
-        if: ${{ startsWith(inputs.ref, 'v') }}
+        if: ${{ startsWith(matrix.ref, 'v') }}
         run: npm run audit -- --production


### PR DESCRIPTION
Relates to #34

---

### Summary

Corrects the audit workflow which was incompletely updated in #34. Use `matrix.ref` rather than the (then removed) `input.ref`.
