### PR TITLE
Use YAML for configuration examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - (`03418df`) Correct the plugin name in the usage documentation text.
+- (`9fa79df`) Use YAML for example configuration in documentation.
 
 ## [0.1.2] - 2022-09-28
 

--- a/README.md
+++ b/README.md
@@ -21,21 +21,17 @@ npm install @ericcornelissen/eslint-plugin-top --save-dev
 Add `@ericcornelissen/top` to the plugins section of your `.eslintrc` config
 file. You can omit the `eslint-plugin-` infix:
 
-```json
-{
-  "plugins": ["@ericcornelissen/top"]
-}
+```yaml
+plugins:
+  - '@ericcornelissen/top'
 ```
 
 Then configure the rules you want to use under the rules section.
 
-```json
-{
-  "rules": {
-    "@ericcornelissen/top/no-top-level-variables": 2,
-    "@ericcornelissen/top/no-top-level-side-effect": 2
-  }
-}
+```yaml
+rules:
+  '@ericcornelissen/top/no-top-level-variables': error
+  '@ericcornelissen/top/no-top-level-side-effect': error
 ```
 
 ## Supported Rules

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -32,17 +32,14 @@ export default function () {
 
 ### Options
 
-```json
-{
-  "rules": {
-    "@ericcornelissen/top/no-top-level-variables": [
-      "error",
-      {
-        "kind": ["const", "let", "var"]
-      }
-    ]
-  }
-}
+```yaml
+rules:
+  '@ericcornelissen/top/no-top-level-variables':
+    - error
+    - kind:
+        - const
+        - let
+        - var
 ```
 
 #### kind


### PR DESCRIPTION
### Summary

Like this project's configuration files (ref. 2d16cacefba27e0b9862de125725b56d324744a4), prefer YAML for config examples in documentation as well.