### PR TITLE
Use incremental mode for mutation testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -151,6 +151,13 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
+      - name: Cache Stryker incremental report
+        uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1
+        with:
+          path: _reports/mutation/stryker-incremental.json
+          key: mutation-${{ github.run_number }}
+          restore-keys: |
+            mutation-
       - name: Install Node.js dependencies
         run: npm ci
       - name: Run mutation tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ericcornelissen/eslint-plugin-top": "file:./",
         "@rollup/plugin-node-resolve": "14.1.0",
         "@stryker-mutator/core": "6.2.2",
+        "@stryker-mutator/mocha-runner": "6.2.2",
         "@stryker-mutator/typescript-checker": "6.2.2",
         "@types/eslint": "8.4.6",
         "@types/mocha": "10.0.0",
@@ -1050,6 +1051,24 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@stryker-mutator/mocha-runner": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-runner/-/mocha-runner-6.2.2.tgz",
+      "integrity": "sha512-yc6YNzKTal7ARu0sfJ6ERb8yQtTjgmoVtIEeRyDWW6JooUDERFq92Fw9rMBp+fW8Qgf5ZTdxbvFtpN0GtGe3Jw==",
+      "dev": true,
+      "dependencies": {
+        "@stryker-mutator/api": "6.2.2",
+        "@stryker-mutator/util": "6.2.2",
+        "tslib": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~6.2.0",
+        "mocha": ">= 7.2 < 11"
       }
     },
     "node_modules/@stryker-mutator/typescript-checker": {
@@ -7256,6 +7275,7 @@
         "@ericcornelissen/eslint-plugin-top": "file:",
         "@rollup/plugin-node-resolve": "14.1.0",
         "@stryker-mutator/core": "6.2.2",
+        "@stryker-mutator/mocha-runner": "6.2.2",
         "@stryker-mutator/typescript-checker": "6.2.2",
         "@types/eslint": "8.4.6",
         "@types/mocha": "10.0.0",
@@ -8045,6 +8065,17 @@
             "@stryker-mutator/util": "6.2.2",
             "angular-html-parser": "~1.8.0",
             "weapon-regex": "~1.0.2"
+          }
+        },
+        "@stryker-mutator/mocha-runner": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-runner/-/mocha-runner-6.2.2.tgz",
+          "integrity": "sha512-yc6YNzKTal7ARu0sfJ6ERb8yQtTjgmoVtIEeRyDWW6JooUDERFq92Fw9rMBp+fW8Qgf5ZTdxbvFtpN0GtGe3Jw==",
+          "dev": true,
+          "requires": {
+            "@stryker-mutator/api": "6.2.2",
+            "@stryker-mutator/util": "6.2.2",
+            "tslib": "~2.4.0"
           }
         },
         "@stryker-mutator/typescript-checker": {
@@ -12451,6 +12482,17 @@
         "@stryker-mutator/util": "6.2.2",
         "angular-html-parser": "~1.8.0",
         "weapon-regex": "~1.0.2"
+      }
+    },
+    "@stryker-mutator/mocha-runner": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-runner/-/mocha-runner-6.2.2.tgz",
+      "integrity": "sha512-yc6YNzKTal7ARu0sfJ6ERb8yQtTjgmoVtIEeRyDWW6JooUDERFq92Fw9rMBp+fW8Qgf5ZTdxbvFtpN0GtGe3Jw==",
+      "dev": true,
+      "requires": {
+        "@stryker-mutator/api": "6.2.2",
+        "@stryker-mutator/util": "6.2.2",
+        "tslib": "~2.4.0"
       }
     },
     "@stryker-mutator/typescript-checker": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ericcornelissen/eslint-plugin-top": "file:./",
     "@rollup/plugin-node-resolve": "14.1.0",
     "@stryker-mutator/core": "6.2.2",
+    "@stryker-mutator/mocha-runner": "6.2.2",
     "@stryker-mutator/typescript-checker": "6.2.2",
     "@types/eslint": "8.4.6",
     "@types/mocha": "10.0.0",

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -1,5 +1,7 @@
 // Check out StrykerJS at: https://stryker-mutator.io/
 
+const reportDir = '_reports/mutation';
+
 module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
@@ -11,6 +13,9 @@ module.exports = {
     spec: ['tests/unit/**/*.test.ts']
   },
 
+  incremental: true,
+  incrementalFile: `${reportDir}/stryker-incremental.json`,
+
   timeoutMS: 25000,
   timeoutFactor: 2.5,
 
@@ -20,7 +25,7 @@ module.exports = {
 
   reporters: ['clear-text', 'dashboard', 'html', 'progress'],
   htmlReporter: {
-    fileName: '_reports/mutation/index.html'
+    fileName: `${reportDir}/index.html`
   },
   thresholds: {
     // TODO: add thresholds

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -4,8 +4,11 @@ module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
   mutate: ['lib/**/*.ts'],
-  commandRunner: {
-    command: 'npm run test'
+
+  testRunner: 'mocha',
+  mochaOptions: {
+    config: '.mocharc.yml',
+    spec: ['tests/unit/**/*.test.ts']
   },
 
   timeoutMS: 25000,


### PR DESCRIPTION
Closes #50 

---

### Summary

Use Stryker's incremental mode to speed up mutation testing both locally and in the CI. In the CI, this provides a speedup that takes the mutation test check duration (in an ideal scenario) from [~3m 59s](https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/3190338312/jobs/5205328299) to [~0m 15s](https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/3190411288/jobs/5205499638), or only about 6% of the time.

To achieve this, also install the Mocha Runner for Stryker as a devDependency and update the Stryker configuration to use the Mocha runner to run tests. Using the Mocha Runner enables most benefits of incremental mode (in contrast to using the `commandRunner` option).