### PR TITLE
Add `audit:runtime` npm script

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm run audit
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
+        # TODO: Replace with `run: npm run audit:runtime`
         run: npm run audit -- --production
   secrets:
     name: Secrets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,13 +182,19 @@ node scripts/run-compat-tests.js
 
 ##### Vulnerabilities
 
-To scan for vulnerabilities in Node.js dependencies, run:
+To scan for vulnerabilities in all npm dependencies, run:
 
 ```shell
 npm run audit
 ```
 
-This uses [better-npm-audit] to audit dependencies, which allows for having
+To scan for vulnerabilities in runtime npm dependencies only, run:
+
+```shell
+npm run audit:runtime
+```
+
+Both use [better-npm-audit] to audit dependencies, which allows for having
 exceptions defined in the `.nsprc` file.
 
 ##### Licenses

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "pretest:compat": "npm run build",
     "_prettier": "prettier ./**/*.{js,json,md,ts,yml} --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
+    "audit:runtime": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.ts",
     "check-licenses": "fossa analyze && fossa test",
     "clean": "git clean --force -X .temp/ _reports/ index.js",


### PR DESCRIPTION
Relates to #18

---

### Summary

Add a new npm script called `audit:runtime` that is intended to be used to audit runtime (aka production) dependencies only. This is particularly useful for end-users or when auditing on a version git ref rather than development git ref (to see if a particular release had dependencies with known vulnerabilities), e.g. [in the CI](https://github.com/ericcornelissen/eslint-plugin-top/blob/451c8bf1d6ad82dd11cc716aaa3630e1c7c786ca/.github/workflows/reusable-audit.yml#L37).