### PR TITLE
Drop "audit:runtime" script

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -29,13 +29,9 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Audit all npm dependencies
+      - name: Audit npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
         run: npm run audit
-      - name: Audit production npm dependencies
-        if: ${{ startsWith(matrix.ref, 'v') }}
-        # TODO: Replace with `run: npm run audit:runtime`
-        run: npm run audit -- --production
   secrets:
     name: Secrets
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,19 +182,13 @@ node scripts/run-compat-tests.js
 
 ##### Vulnerabilities
 
-To scan for vulnerabilities in all npm dependencies, run:
+To scan for vulnerabilities in the npm dependencies, run:
 
 ```shell
 npm run audit
 ```
 
-To scan for vulnerabilities in runtime npm dependencies only, run:
-
-```shell
-npm run audit:runtime
-```
-
-Both use [better-npm-audit] to audit dependencies, which allows for having
+This uses [better-npm-audit] to audit dependencies, which allows for having
 exceptions defined in the `.nsprc` file.
 
 ##### Licenses

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "pretest:compat": "npm run build",
     "_prettier": "prettier ./**/*.{js,json,md,ts,yml} --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
-    "audit:runtime": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.ts",
     "check-licenses": "fossa analyze && fossa test",
     "clean": "git clean --force -X .temp/ _reports/ index.js",


### PR DESCRIPTION
Closes #58

---

### Summary

Auditing runtime dependencies only is unnecessary as this is a library. Not only because there's currently no runtime dependencies, but also because it is generally not problematic[^1] for runtime dependencies being depended upon to have known vulnerabilities. The vulnerable code is never run in an interesting setting within the project and users of the library can always upgrade to a safe version because we would be using version ranges.

This suggestion is predicated on the assumption that bumping a runtime dependency from, say, `^2.0.0` to `^2.1.0` in order to "fix" the vulnerable dependency is a breaking change.

[^1]: This assessment excludes vulnerabilities in the malware category.