### PR TITLE
Update license check in CI to use the Fossa Action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,13 +65,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - name: Install Fossa CLI
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+      - name: Scan licenses
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
       - name: Check licenses
-        run: npm run check-licenses
-        env:
-          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #41

---

### Summary

Replace downloading the [Fossa CLI](https://github.com/fossas/fossa-cli) in the CI by using the [Fossa Action](https://github.com/fossas/fossa-action). Unfortunately this still relies on the Fossa API secret, with all associated drawbacks.