### PR TITLE
Narrow supported ESLint versions range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - (`03418df`) Correct the plugin name in the usage documentation text.
+- (`ceaa619`) Improve specificity of supported ESLint versions.
 - (`9fa79df`) Use YAML for example configuration in documentation.
 
 ## [0.1.2] - 2022-09-28

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "@ericcornelissen/eslint-plugin-top",
       "version": "0.1.2",
-      "dev": true,
       "license": "ISC",
       "devDependencies": {
         "@ericcornelissen/eslint-plugin-top": "file:./",
@@ -40,7 +39,7 @@
         "node": "12.x || 14.x || 16.x || 18.x"
       },
       "peerDependencies": {
-        "eslint": ">=6"
+        "eslint": "6.x || 7.x || 8.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "peerDependencies": {
-    "eslint": ">=6"
+    "eslint": "6.x || 7.x || 8.x"
   },
   "devDependencies": {
     "@ericcornelissen/eslint-plugin-top": "file:./",


### PR DESCRIPTION
Relates to #20

---

### Summary

Update the supported Node.js version range to be the union of:

- All previously supported version by the plugin.
- All currently released version of ESLint out there.

If a new major version of ESLint is released, compatibility can be verified. If all is well, the version ranges for ESLint as a `peerDependency` can be updated and a new release can be published.

### Checklist

- [x] Update the version range in `package*.json`
- [x] Update the `CHANGELOG.md`
