### PR TITLE
Update the Stryker configuration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Cache Stryker incremental report
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: _reports/mutation/stryker-incremental.json
+          path: .cache/stryker-incremental.json
           key: mutation-${{ github.run_number }}
           restore-keys: |
             mutation-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache/
 .temp/
 _reports/
 index.js

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "audit:runtime": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.ts",
     "check-licenses": "fossa analyze && fossa test",
-    "clean": "git clean --force -X .temp/ _reports/ index.js",
+    "clean": "git clean --force -X .cache/ .temp/ _reports/ index.js",
     "coverage": "c8 --reporter=lcov --reporter=text --reports-dir=_reports/coverage npm run test",
     "format": "npm run _prettier -- --write",
     "lint": "npm run _prettier -- --check",

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -1,7 +1,5 @@
 // Check out StrykerJS at: https://stryker-mutator.io/
 
-const reportDir = '_reports/mutation';
-
 module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
@@ -14,10 +12,7 @@ module.exports = {
   },
 
   incremental: true,
-  incrementalFile: `${reportDir}/stryker-incremental.json`,
-
-  timeoutMS: 25000,
-  timeoutFactor: 2.5,
+  incrementalFile: '.cache/stryker-incremental.json',
 
   disableTypeChecks: '{lib,tests}/**/*.ts',
   checkers: ['typescript'],
@@ -25,12 +20,12 @@ module.exports = {
 
   reporters: ['clear-text', 'dashboard', 'html', 'progress'],
   htmlReporter: {
-    fileName: `${reportDir}/index.html`
+    fileName: '_reports/mutation/index.html'
   },
   thresholds: {
     // TODO: add thresholds
   },
 
   tempDirName: '.temp/stryker',
-  cleanTempDir: false
+  cleanTempDir: true
 };


### PR DESCRIPTION
1. Store Stryker's incremental file in a cache dir. This makes more sense semantically.
2. Instruct Stryker to remove temporary dir if successful. Keeping it has no real purpose (plus, it's kept if something goes wrong, aka when it has a purpose).
4. Remove the timeout configuration. Not necessary for this project.