### PR TITLE
Update use of deprecated `::set-output` in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,11 +91,11 @@ jobs:
         id: version
         run: |
           VERSION="v$(jq -r '.version' < package.json)"
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
-            echo "::set-output name=released::true"
+            echo "released=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=released::false"
+            echo "released=false" >> $GITHUB_OUTPUT
           fi
       - name: Publish tag to remote
         if: ${{ steps.version.outputs.released == 'false' }}


### PR DESCRIPTION
Closes #65

---

### Summary

n/a