### PR TITLE
Increase test coverage

### DIFF
--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -36,7 +36,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
           node.declarations[0].init.callee.name === 'require';
         const isLiteral =
           node.kind === 'const' &&
-          node.declarations[0].init?.type === 'Literal';
+          (node.declarations[0].init as any).type === 'Literal';
 
         if (isMatching && !isRequire && !isLiteral) {
           if (isTopLevel(node)) {

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -88,6 +88,16 @@ const invalid: RuleTester.InvalidTestCase[] = [
         messageId: 'message'
       }
     ]
+  },
+  {
+    code: `
+      var foo;
+    `,
+    errors: [
+      {
+        messageId: 'message'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #9 

---

### Summary

Add additional test cases guided by test coverage.

- Test uninitialized variable for `no-top-level-variables` rule. (2bd3d7f0fec6482d457404024cc2057d426c644c)
  - For if `.init === null` at [`no-top-level-variables.ts#L34`](https://github.com/ericcornelissen/eslint-plugin-top/blob/e6059a8ac5c8c7890a771f6de84bc12aa1d2f63d/lib/rules/no-top-level-variables.ts#L34).
- Don't unnecessarily check if `.init !== null` for `const` declarations.