### PR TITLE
Update the .npmignore allowlist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,7 @@
 # Except the ones we want to publish
 !docs/
 !index.js
+!LICENSE
+!package.json
 !README.md
+!SECURITY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`84b0145`) Add the Security Policy to the published package.
 - (`03418df`) Correct the plugin name in the usage documentation text.
 - (`ceaa619`) Improve specificity of supported ESLint versions.
 - (`9fa79df`) Use YAML for example configuration in documentation.


### PR DESCRIPTION
### Summary

- Add `LICENSE` and `package.json` explicitly (even though they're included by default).
- Add `SECURITY.md` in order to include the Security Policy in the published package.