### PR TITLE
Improve hightlights for the `no-top-level-variables` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 - (`84b0145`) Add the Security Policy to the published package.
 - (`03418df`) Correct the plugin name in the usage documentation text.
 - (`ceaa619`) Improve specificity of supported ESLint versions.
+- (`73ca9c0`) Improve violation highlights for `no-top-level-variables`.
 - (`9fa79df`) Use YAML for example configuration in documentation.
 
 ## [0.1.2] - 2022-09-28

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -40,7 +40,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
 
         if (isMatching && !isRequire && !isLiteral) {
           if (isTopLevel(node)) {
-            context.report({node, messageId: 'message'});
+            context.report({node: node.declarations[0], messageId: 'message'});
           }
         }
       }

--- a/tests/compat/snapshots.ts
+++ b/tests/compat/snapshots.ts
@@ -1,6 +1,6 @@
 export const noTopLevelVariablesViolation = `
 <text>
-  1:1  error  Unexpected variable at the top level  @ericcornelissen/top/no-top-level-variables
+  1:5  error  Unexpected variable at the top level  @ericcornelissen/top/no-top-level-variables
 
 ✖ 1 problem (1 error, 0 warnings)
 

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -57,7 +57,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message'
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 16
       }
     ]
   },
@@ -68,7 +72,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message'
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 16
       }
     ]
   },
@@ -85,7 +93,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     ],
     errors: [
       {
-        messageId: 'message'
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 19
       }
     ]
   },
@@ -95,7 +107,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message'
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 8
       }
     ]
   }


### PR DESCRIPTION
Closes #85

---

### Summary

Improve the highlights - i.e. the part of the code that is reported by ESLint and gets the squiggly line in your editor - for [`no-top-level-variables` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/20ecc9338a62e86f6124884509f535585c5d4b61/docs/rules/no-top-level-variables.md) by highlighting the violating declaration rather than the entire statement.