### PR TITLE
Check if a given node `isTopLevel` only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`ab3fd6b`) Improve performance of `no-top-level-variables`.
 
 ## [0.1.3] - 2022-10-31
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -30,7 +30,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
     return {
       VariableDeclaration: (node) => {
         const isMatching = Array.from(options.kind).includes(node.kind);
-        if (!isMatching) {
+        if (!isTopLevel(node) || !isMatching) {
           return;
         }
 
@@ -44,12 +44,10 @@ export const noTopLevelVariables: Rule.RuleModule = {
             (declaration.init as any).type === 'Literal';
 
           if (!isRequire && !isLiteral) {
-            if (isTopLevel(node)) {
-              context.report({
-                node: declaration,
-                messageId: 'message'
-              });
-            }
+            context.report({
+              node: declaration,
+              messageId: 'message'
+            });
           }
         });
       }


### PR DESCRIPTION
Relates to #87

---

### Summary

Improve the performance of the [`no-top-level-variables` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/7df20460a19f69a57bfe10659963ea48e1e33502/docs/rules/no-top-level-variables.md) by only checking if a given node [`isTopLevel`](https://github.com/ericcornelissen/eslint-plugin-top/blob/7df20460a19f69a57bfe10659963ea48e1e33502/lib/helpers.ts#L3-L9) only once, rather than for each declaration individually.