### PR TITLE
Use `npm run audit:runtime` in reusable audit

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -34,8 +34,7 @@ jobs:
         run: npm run audit
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
-        # TODO: Replace with `run: npm run audit:runtime`
-        run: npm run audit -- --production
+        run: npm run audit:runtime
   secrets:
     name: Secrets
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #58

---

### Summary

Update the `reusable-audit.yml` workflow to use the `npm run audit:runtime` command.