### PR TITLE
Create command to run compatibility tests on all Node.js versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,10 +171,10 @@ npm run test:compat
 
 To check compatibility with all Node.js versions, the continuous integration
 runs the compatibility test suite on every supported Node.js version. You can
-also do this locally using a script (requires [Docker]):
+also do this locally using (requires [Docker]):
 
 ```shell
-node scripts/run-compat-tests.js
+npm run test:compat-all
 ```
 
 #### Auditing

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "pretest:compat": "npm run build",
+    "pretest:compat-all": "npm run build",
     "_prettier": "prettier ./**/*.{js,json,md,ts,yml} --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
     "audit:runtime": "better-npm-audit audit --production",
@@ -72,6 +73,7 @@
     "lint:ts": "eslint . --report-unused-disable-directives --ext .ts",
     "test": "mocha tests/unit --recursive",
     "test:compat": "mocha tests/compat --recursive",
+    "test:compat-all": "node scripts/run-compat-tests.js",
     "test:mutation": "stryker run stryker.config.js",
     "test:watch": "npm run test -- --watch"
   }

--- a/scripts/run-compat-tests.js
+++ b/scripts/run-compat-tests.js
@@ -39,10 +39,6 @@ function runCompatibilityTestsOn(nodeVersion) {
   };
 }
 
-print('Building...');
-cp.spawnSync('npm', ['run', 'build']);
-reprintln('Built\n');
-
 const nodeVersions = ['12', '14', '16', '18'];
 
 const fails = [];


### PR DESCRIPTION
Relates to #17, #97


---


### Summary

Add a new `npm run` command in favor of invoking `node scripts/run-compat-tests.js` manually at the developers convenience.