### PR TITLE
Enable licensee corrections

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -14,9 +14,6 @@
       "Unlicense"
     ]
   },
-  "packages": {
-    "docopt": "0.6.2",
-    "prelude-ls": "1.1.2"
-  },
-  "corrections": false
+  "packages": {},
+  "corrections": true
 }


### PR DESCRIPTION
Relates to #76

---

### Summary

Update the [licensee](https://www.npmjs.com/package/licensee) configuration to enable corrections to avoid, as much as possible, having to manually review dependencies and add them as exceptions.

Per the licensee documentation:

> The `corrections` flag toggles community corrections to npm package license metadata. When enabled, `licensee` will check against `license` values from [npm-license-corrections](https://www.npmjs.com/package/npm-license-corrections) when available, and also use [correct-license-metadata](https://www.npmjs.com/package/correct-license-metadata) to try to correct old-style `licenses` arrays and other unambiguous, but invalid, metadata.