### PR TITLE
Allow for top-level assignment of `MemberExpression`

### DIFF
--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -51,6 +51,11 @@ const valid: RuleTester.ValidTestCase[] = [
     code: `
       const path = require('path'), foo = 'bar';
     `
+  },
+  {
+    code: `
+      const isArray = Array.isArray;
+    `
   }
 ];
 
@@ -234,6 +239,36 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 18
+      }
+    ]
+  },
+  {
+    code: `
+      var isArray = Array.isArray;
+    `,
+    options: [],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 28
+      }
+    ]
+  },
+  {
+    code: `
+      let isArray = Array.isArray;
+    `,
+    options: [],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 28
       }
     ]
   }


### PR DESCRIPTION
Closes #83
Relates to #86 

---

### Summary

Update the [`no-top-level-variables` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/6750889b5431cc66619dab0a9ac25281e1687395/docs/rules/no-top-level-variables.md) to, optionally, allow for assignments of `MemberExpression`s in `const` declarations.