### PR TITLE
Lint shell scripts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -93,6 +93,8 @@ jobs:
         run: npm ci
       - name: Lint MarkDown
         run: npm run lint:md
+      - name: Lint shell scripts
+        run: npm run lint:sh
       - name: Lint TypeScript
         run: npm run lint:ts
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ To be able to contribute you need the following tooling:
 - [git];
 - [Node.js] v18.0.0 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
+- (Optional) [ShellCheck];
 - (Optional) [Docker];
 
 ### Workflow
@@ -119,6 +120,7 @@ command to check your changes if applicable:
 | File type          | Command           | Linter         |
 | :----------------- | :---------------- | :------------- |
 | MarkDown (`.md`)   | `npm run lint:md` | [markdownlint] |
+| Shell (`.sh`)      | `npm run lint:sh` | [ShellCheck]   |
 | TypeScript (`.ts`) | `npm run lint:ts` | [ESLint]       |
 
 #### Testing
@@ -236,4 +238,5 @@ This will create a file called `index.js`. Note that this file ignored by git.
 [rollup.js]: https://rollupjs.org/guide/en/
 [ruletester]: https://eslint.org/docs/latest/developer-guide/nodejs-api#ruletester
 [security policy]: ./SECURITY.md
+[shellcheck]: https://github.com/koalaman/shellcheck
 [stryker]: https://stryker-mutator.io/

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lint:md": "npm run lint:md:text && npm run lint:md:code",
     "lint:md:code": "eslint **/*.md --ext .md,.javascript,.yml",
     "lint:md:text": "markdownlint --dot --ignore-path .gitignore .",
+    "lint:sh": "shellcheck scripts/*.sh",
     "lint:ts": "eslint . --report-unused-disable-directives --ext .ts",
     "test": "mocha tests/unit --recursive",
     "test:compat": "mocha tests/compat --recursive",


### PR DESCRIPTION
Relates to #112

---

### Summary

Add [ShellCheck] as an optional dependency for development and use it to lint shell scripts.

[shellcheck]: https://github.com/koalaman/shellcheck