### PR TITLE
Extract test helpers from src/ to tests/

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,4 +1,4 @@
-import {Rule, RuleTester} from 'eslint';
+import {Rule} from 'eslint';
 
 export function isTopLevel(node: Rule.Node) {
   let scope = node.parent;
@@ -6,13 +6,4 @@ export function isTopLevel(node: Rule.Node) {
     scope = scope.parent;
   }
   return scope.type === 'Program';
-}
-
-export function trimTestCases<
-  T extends RuleTester.InvalidTestCase | RuleTester.ValidTestCase
->(testCase: T): T {
-  return {
-    ...testCase,
-    code: testCase.code.trim()
-  };
 }

--- a/tests/unit/helpers.ts
+++ b/tests/unit/helpers.ts
@@ -1,0 +1,10 @@
+import {RuleTester} from 'eslint';
+
+export function trimTestCases<
+  T extends RuleTester.InvalidTestCase | RuleTester.ValidTestCase
+>(testCase: T): T {
+  return {
+    ...testCase,
+    code: testCase.code.trim()
+  };
+}

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -1,6 +1,6 @@
 import * as parser from '@typescript-eslint/parser';
 import {RuleTester} from 'eslint';
-import {trimTestCases} from '../../lib/helpers';
+import {trimTestCases} from './helpers';
 import {noTopLevelSideEffect} from '../../lib/rules/no-top-level-side-effect';
 
 const valid: RuleTester.ValidTestCase[] = [

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -1,6 +1,6 @@
 import * as parser from '@typescript-eslint/parser';
 import {RuleTester} from 'eslint';
-import {trimTestCases} from '../../lib/helpers';
+import {trimTestCases} from './helpers';
 import {noTopLevelVariables} from '../../lib/rules/no-top-level-variables';
 
 const valid: RuleTester.ValidTestCase[] = [


### PR DESCRIPTION
### Summary

Currently, helper functionality for tests is located in `src/helpers.ts`. This may be confusing as it's not used by the library's source code. Hence, move it to a dedicated helper module located with the tests.

Note that the moved code would not end up in the build output (`index.js`) since it's unused. Hence, this change doesn't need to be listed in the changelog.