### PR TITLE
Test against variables & side effects in top-level BlockStatements

### DIFF
--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -57,6 +57,14 @@ const invalid: RuleTester.InvalidTestCase[] = [
     switch (foo) {}
     `,
     errors
+  },
+  {
+    code: `
+      {
+        console.log('hello world');
+      }
+    `,
+    errors
   }
 ];
 

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -290,6 +290,23 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 30
       }
     ]
+  },
+  {
+    code: `
+      {
+        let foo = 'bar';
+      }
+    `,
+    options: [],
+    errors: [
+      {
+        messageId: 'message',
+        line: 2,
+        column: 13,
+        endLine: 2,
+        endColumn: 24
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #9 

---

### Summary

Add a test for both the [no-top-level-variables](https://github.com/ericcornelissen/eslint-plugin-top/blob/8fa9fb25239294d6a1d3b5d053824348eb73ca68/docs/rules/no-top-level-variables.md) and [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/8fa9fb25239294d6a1d3b5d053824348eb73ca68/docs/rules/no-top-level-side-effect.md) rule to include a case where the variable or side-effect (resp.) appears in a top-level `"BlockStatement"`. This should produce a violation but was previously untested.