### PR TITLE
Add and configure type-coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -185,3 +185,18 @@ jobs:
         env:
           CI: true
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Install Node.js
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Vet
+        run: npm run vet

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -32,11 +32,16 @@ export const noTopLevelVariables: Rule.RuleModule = {
     ]
   },
   create: (context) => {
-    const options = {
+    const options: {
+      readonly constAllowed: ReadonlyArray<string>;
+      readonly kind: ReadonlyArray<string>;
+    } = {
+      // type-coverage:ignore-next-line
       constAllowed: context.options[0]?.constAllowed || [
         'Literal',
         'MemberExpression'
       ],
+      // type-coverage:ignore-next-line
       kind: context.options[0]?.kind || ['const', 'let', 'var']
     };
 
@@ -54,8 +59,10 @@ export const noTopLevelVariables: Rule.RuleModule = {
             options.constAllowed.includes('MemberExpression');
 
           allowedDeclaration = (declaration) => {
+            // type-coverage:ignore-next-line
             switch ((declaration.init as Expression).type) {
               case 'CallExpression': {
+                // type-coverage:ignore-next-line
                 const callExpression = declaration.init as CallExpression;
                 return (
                   callExpression.callee.type === 'Identifier' &&
@@ -66,6 +73,8 @@ export const noTopLevelVariables: Rule.RuleModule = {
                 return isLiteralAllowed;
               case 'MemberExpression':
                 return isMemberExpressionAllowed;
+              default:
+                return false;
             }
           };
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "prettier": "2.7.1",
         "rollup": "3.4.0",
         "ts-node": "10.9.1",
+        "type-coverage": "2.24.1",
         "typescript": "4.8.4"
       },
       "engines": {
@@ -8305,6 +8306,35 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-coverage": {
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/type-coverage/-/type-coverage-2.24.1.tgz",
+      "integrity": "sha512-+9M6+aiiBEQZECinVLBvQUnmPrHXbI7edcdrPKxhvnLYIobvvPtpywbD3Q32vn8Y1XJHiaCSurN7T16C88htBg==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "1",
+        "type-coverage-core": "^2.24.1"
+      },
+      "bin": {
+        "type-coverage": "bin/type-coverage"
+      }
+    },
+    "node_modules/type-coverage-core": {
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/type-coverage-core/-/type-coverage-core-2.24.1.tgz",
+      "integrity": "sha512-HZCiVINVnrekaEQuq/lKEerAZO/L7rR9vMDs+QRhTfb7HrD2OO6JDQKxJiKLJGAoGhjjQY5248mmX3t/+zLXxg==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "3",
+        "minimatch": "3 || 4 || 5",
+        "normalize-path": "3",
+        "tslib": "1 || 2",
+        "tsutils": "3"
+      },
+      "peerDependencies": {
+        "typescript": "2 || 3 || 4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prettier": "2.7.1",
     "rollup": "3.4.0",
     "ts-node": "10.9.1",
+    "type-coverage": "2.24.1",
     "typescript": "4.8.4"
   },
   "scripts": {
@@ -85,6 +86,7 @@
     "test:compat": "mocha tests/compat --recursive",
     "test:compat-all": "node scripts/run-compat-tests.js",
     "test:mutation": "stryker run stryker.config.js",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "vet": "type-coverage --at-least 100 --cache --cache-directory .cache --project tsconfig.json --strict"
   }
 }

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -307,6 +307,21 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 24
       }
     ]
+  },
+  {
+    code: `
+      const foo = new Bar();
+    `,
+    options: [],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 22
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #124

---

### Summary

Add [type-coverage] as a devDependency for vetting purposes and configure it through CLI arguments (the alternative is to do it in `package.json`, which isn't desired). type-coverage is a vetting tool "to check type coverage for typescript code", in particular reporting on implicit `any`s and unchecked type casts.

[type-coverage]: https://www.npmjs.com/package/type-coverage