### PR TITLE
Update continuous deployment to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,8 @@ jobs:
           # Update what commit the v0 branch points to
           git push origin HEAD:v0
       - name: Publish to npm
-        uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939 # v1.4.3
         if: ${{ steps.version.outputs.released == 'false' }}
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Summary

Update the continuous deployment setup to use `npm publish` instead of a GitHub action ([`JS-DevTools/npm-publish`](https://github.com/JS-DevTools/npm-publish)). The latter has a couple of drawbacks, such as 1) the Action used being poorly maintained and 2) the `NPM_TOKEN` secret being exposed to the action.

The implementation is based on:
https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages