### PR TITLE
Create c8 configuration file

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,15 @@
+{
+  "all": true,
+  "check-coverage": true,
+
+  "include": ["lib/"],
+  "exclude": ["lib/index.ts"],
+
+  "branches": 100,
+  "functions": 100,
+  "lines": 100,
+  "statements": 100,
+
+  "reports-dir": "_reports/coverage",
+  "reporter": ["lcov", "text"]
+}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "audit:runtime": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.ts --configPlugin typescript",
     "clean": "git clean --force -X .cache/ .temp/ _reports/ index.js",
-    "coverage": "c8 --reporter=lcov --reporter=text --reports-dir=_reports/coverage npm run test",
+    "coverage": "c8 --config .c8rc.json npm run test",
     "format": "npm run _prettier -- --write",
     "license-check": "licensee --errors-only",
     "lint": "npm run _prettier -- --check",


### PR DESCRIPTION
Relates to #7, #9, #74

---

### Summary

Move the c8 configuration from `package.json` (CLI args) into a dedicated c8 configuration file, reference the configuration file explicitly to aid with understanding for anyone unfamiliar with c8.