### PR TITLE
Update release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To push a tag
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          fetch-depth: 0 # To obtain all tags
+      - name: Install Node.js
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Check if version is released
+        id: version
+        run: |
+          VERSION="v$(jq -r '.version' < package.json)"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [ "$(git tag --list "$VERSION")" ]; then
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Publish git tag
+        if: ${{ steps.version.outputs.released == 'false' }}
+        run: |
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+      - name: Update major version branch
+        if: ${{ steps.version.outputs.released == 'false' }}
+        run: |
+          git push origin HEAD:v0
+      - name: Publish to npm
+        if: ${{ steps.version.outputs.released == 'false' }}
+        run: |
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       update_type:
@@ -17,11 +14,9 @@ on:
 permissions: read-all
 
 jobs:
-  # Create release
   initiate:
     name: Initiate
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
@@ -75,52 +70,3 @@ jobs:
           branch: release-${{ github.event.inputs.update_type }}
           branch-suffix: random
           commit-message: Version bump
-
-  # Publish release
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
-    permissions:
-      contents: write # To push a tag
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-        with:
-          fetch-depth: 0 # To obtain all tags
-      - name: Install Node.js
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
-        with:
-          cache: npm
-          node-version-file: .nvmrc
-      - name: Install Node.js dependencies
-        run: npm ci
-      - name: Validate release readiness
-        run: |
-          npm run build
-          npm run test
-      - name: Check if version is released
-        id: version
-        run: |
-          VERSION="v$(jq -r '.version' < package.json)"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if [ "$(git tag --list "$VERSION")" ]; then
-            echo "released=true" >> $GITHUB_OUTPUT
-          else
-            echo "released=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Publish tag to remote
-        if: ${{ steps.version.outputs.released == 'false' }}
-        run: |
-          # Create & push a tag for the new version
-          git tag "${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.version }}"
-
-          # Update what commit the v0 branch points to
-          git push origin HEAD:v0
-      - name: Publish to npm
-        if: ${{ steps.version.outputs.released == 'false' }}
-        run: |
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Node.js dependencies
         run: npm ci
+      - uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # tag=v1.7.0
+        id: release-token
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Bump version
         run: npm version ${{ github.event.inputs.update_type }} --no-git-tag-version
       - name: Update CHANGELOG
@@ -42,6 +47,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
         with:
+          token: ${{ steps.release-token.outputs.token }}
           title: New ${{ github.event.inputs.update_type }} release
           body: |
             _This Pull Request was created automatically_


### PR DESCRIPTION
### Summary

- Follow the [`peter-evans/create-pull-request`'s "Authenticating with GitHub App generated tokens" setup](https://github.com/peter-evans/create-pull-request/blob/d36c8e08631d4fb3eeef33322f981071ac12cdc2/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) to ensure GitHub Actions workflows are run for release Pull Requests.
- Split the _release PR_ and _publish_ jobs into separate workflows to avoid `if`s on the workflow trigger.