### PR TITLE
Improve test suite for `no-top-level-variables` rule

### DIFF
--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -3,11 +3,16 @@ import type {Expression, CallExpression, VariableDeclarator} from 'estree';
 import {Rule} from 'eslint';
 import {isTopLevel} from '../helpers';
 
+const violationMessage = 'Unexpected variable at the top level';
+
+const constAllowedValues = ['Literal', 'MemberExpression'];
+const kindValues = ['const', 'let', 'var'];
+
 export const noTopLevelVariables: Rule.RuleModule = {
   meta: {
     type: 'problem',
     messages: {
-      message: `Unexpected variable at the top level`
+      message: violationMessage
     },
     schema: [
       {
@@ -17,14 +22,14 @@ export const noTopLevelVariables: Rule.RuleModule = {
             type: 'array',
             minItems: 0,
             items: {
-              enum: ['Literal', 'MemberExpression']
+              enum: constAllowedValues
             }
           },
           kind: {
             type: 'array',
             minItems: 1,
             items: {
-              enum: ['const', 'let', 'var']
+              enum: kindValues
             }
           }
         }
@@ -37,12 +42,9 @@ export const noTopLevelVariables: Rule.RuleModule = {
       readonly kind: ReadonlyArray<string>;
     } = {
       // type-coverage:ignore-next-line
-      constAllowed: context.options[0]?.constAllowed || [
-        'Literal',
-        'MemberExpression'
-      ],
+      constAllowed: context.options[0]?.constAllowed || constAllowedValues,
       // type-coverage:ignore-next-line
-      kind: context.options[0]?.kind || ['const', 'let', 'var']
+      kind: context.options[0]?.kind || kindValues
     };
 
     return {

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -3,6 +3,7 @@
 module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
+  ignoreStatic: true,
   mutate: ['lib/**/*.ts'],
 
   testRunner: 'mocha',

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -56,6 +56,26 @@ const valid: RuleTester.ValidTestCase[] = [
     code: `
       const isArray = Array.isArray;
     `
+  },
+  {
+    code: `
+      const pi = 3.14;
+    `,
+    options: [
+      {
+        constAllowed: ['Literal']
+      }
+    ]
+  },
+  {
+    code: `
+      const isArray = Array.isArray;
+    `,
+    options: [
+      {
+        constAllowed: ['MemberExpression']
+      }
+    ]
   }
 ];
 
@@ -320,6 +340,58 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 22
+      }
+    ]
+  },
+  {
+    code: `
+      const isArray = Array.isArray;
+    `,
+    options: [
+      {
+        constAllowed: ['Literal']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 30
+      }
+    ]
+  },
+  {
+    code: `
+      const pi = 3.14;
+    `,
+    options: [
+      {
+        constAllowed: ['MemberExpression']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 16
+      }
+    ]
+  },
+  {
+    code: `
+      var foo = bar();
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 16
       }
     ]
   }


### PR DESCRIPTION
Relates to #9, #126

---

### Summary

Update the [`no-top-level-variables` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/feabdc08aefa99f3b8f8a8783a179a9e30e9da9b/docs/rules/no-top-level-variables.md)'s test suite with additional test cases based on the mutation report for the rules source code.