### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top
     permissions:
       contents: write # To push a tag
     steps:


### PR DESCRIPTION
Related to #145

---

### Summary

Try out using an [environment for deployment] in order to limit the scope of the `NPM_TOKEN` secret from _all workflows_ to _workflows with the right environment_.

[environment for deployment]: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment