### PR TITLE
Improve test suite for no-top-level-side-effects rule

### DIFF
--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -1,6 +1,8 @@
 import {Rule} from 'eslint';
 import {isTopLevel} from '../helpers';
 
+const violationMessage = 'Side effects in toplevel are not allowed';
+
 function sideEffect(context: Rule.RuleContext) {
   return (node: Rule.Node) => {
     if (isTopLevel(node)) {
@@ -16,7 +18,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
   meta: {
     type: 'problem',
     messages: {
-      message: 'Side effects in toplevel are not allowed.'
+      message: violationMessage
     }
   },
   create: (context) => {

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -13,6 +13,13 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
+      (() => {
+        return '';
+      })();
+    `
+  },
+  {
+    code: `
     export function foobar() {}
     `
   },
@@ -21,6 +28,30 @@ const valid: RuleTester.ValidTestCase[] = [
       module.exports = {};
       exports = {};
       exports.foobar = {};
+    `
+  },
+  {
+    code: `
+      function foobar() {
+        if (foo === bar) {
+          foo = "bar";
+        }
+
+        for (let i = 0; i < 2; i++) {
+          foo = bar[i];
+        }
+
+        while (foo !== "bar") {
+          foo = "bar";
+        }
+
+        switch (foo) {
+        case "bar":
+          return "foo";
+        default:
+          return "bar";
+        }
+      }
     `
   }
 ];
@@ -63,6 +94,24 @@ const invalid: RuleTester.InvalidTestCase[] = [
       {
         console.log('hello world');
       }
+    `,
+    errors
+  },
+  {
+    code: `
+      notModule.exports = {};
+    `,
+    errors
+  },
+  {
+    code: `
+      notExports = {};
+    `,
+    errors
+  },
+  {
+    code: `
+      notExports.foobar = {};
     `,
     errors
   }


### PR DESCRIPTION
Relates to #9, #146

---

### Summary

Update the [`no-top-level-side-effect` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/3931e87b0d55a8a16009eb238efe8978d676d86a/docs/rules/no-top-level-side-effect.md)'s test suite with additional test cases based on the mutation report for the rules source code.