### PR TITLE
Set mutation testing thresholds

### DIFF
--- a/stryker.config.js
+++ b/stryker.config.js
@@ -4,7 +4,7 @@ module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
   ignoreStatic: true,
-  mutate: ['lib/**/*.ts'],
+  mutate: ['lib/**/*.ts', '!lib/index.ts'],
 
   testRunner: 'mocha',
   mochaOptions: {

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -24,7 +24,9 @@ module.exports = {
     fileName: '_reports/mutation/index.html'
   },
   thresholds: {
-    // TODO: add thresholds
+    high: 100,
+    low: 100,
+    break: 100
   },
 
   tempDirName: '.temp/stryker',


### PR DESCRIPTION
Relates to #9 

---

### Summary

Finalize the work of #9 by adjusting the Stryker configuration to enforce 100% mutation test coverage.