### PR TITLE
Pin all runner images in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-config.yml
+++ b/.github/workflows/check-config.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   codecov:
     name: Codecov
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -33,7 +33,7 @@ jobs:
           path: index.js
   codeql:
     name: CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     permissions:
@@ -50,7 +50,7 @@ jobs:
         uses: github/codeql-action/analyze@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
   formatting:
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -65,7 +65,7 @@ jobs:
         run: npm run lint
   licenses:
     name: Licenses
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -80,7 +80,7 @@ jobs:
         run: npm run license-check
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -114,7 +114,7 @@ jobs:
         run: npm run lint:ci
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:
@@ -136,7 +136,7 @@ jobs:
           file: ./_reports/coverage/lcov.info
   test-compat:
     name: Compatibility tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test
     strategy:
@@ -166,7 +166,7 @@ jobs:
         run: npm run test:compat --ignore-scripts
   test-mutation:
     name: Mutation tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test
     steps:
@@ -193,7 +193,7 @@ jobs:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
   vet:
     name: Vet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment:
       name: npm
       url: https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   initiate:
     name: Initiate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   npm:
     name: npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +37,7 @@ jobs:
         run: npm run audit:runtime
   secrets:
     name: Secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0


### PR DESCRIPTION
### Summary

Update all GitHub Actions workflows to use a specific runner image for all jobs. Doing this should help with reproducibility.