### PR TITLE
Add `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,14 +89,10 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
-      - name: Install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: 1.17
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install dependencies
-        run: |
-          npm ci
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
+        run: npm ci
       - name: Set setup success flag
         id: setup
         run: echo 'succeeded=true' >> "$GITHUB_OUTPUT"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+# Check out asdf at: https://asdf-vm.com/
+
+actionlint 1.6.22
+shellcheck 0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ To be able to contribute you need the following tooling:
 - [git];
 - [Node.js] v18.0.0 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
-- (Optional) [actionlint] and [ShellCheck];
+- (Optional) [actionlint] (see `.tool-versions` for prefered version);
+- (Optional) [ShellCheck] (see `.tool-versions` for prefered version);
 - (Optional) [Docker];
 
 ### Workflow


### PR DESCRIPTION
Relates to #170

## Summary

Create a `.tool-versions` file to explicitly track tools. This file is first a configuration format for [asdf], but is also human-readable and thus can be used to know and track what versions of dependencies _should_ be used (and as such it's referenced in the Contributing Guidelines for those that don't use [asdf]).

[asdf]: https://asdf-vm.com/