### PR TITLE
Ensure all vetting tools are always run in the CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -207,5 +207,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Vet
-        run: npm run vet
+      - name: Set setup success flag
+        id: setup
+        run: echo 'succeeded=true' >> "$GITHUB_OUTPUT"
+      - name: Vet imports
+        if: ${{ steps.setup.outputs.succeeded }}
+        run: npm run vet:imports
+      - name: Vet types
+        if: ${{ steps.setup.outputs.succeeded }}
+        run: npm run vet:types


### PR DESCRIPTION
Relates to #185

## Summary

Update the "Check / Vet" job such that it always runs all vetting tools regardless of any one tool failing. The job itself will still fail if any one vetting tool reports an error.
