### PR TITLE
Update `.licensee.json`

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -14,8 +14,6 @@
       "Unlicense"
     ]
   },
-  "packages": {
-    "scss-parser": "1.0.6"
-  },
+  "packages": {},
   "corrections": true
 }


### PR DESCRIPTION
## Summary

Remove `scss-parser` exception since it's no longer a (transitive) dependency of project. It was added in #177 as it's a dependency of `depcheck`. However, #127 removed `depcheck` and thus also `scss-parser`.