### PR TITLE
Refactor `no-top-level-side-effects` for readability

### DIFF
--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -4,7 +4,7 @@ import {isTopLevel} from '../helpers';
 
 const violationMessage = 'Side effects in toplevel are not allowed';
 
-function sideEffect(context: Rule.RuleContext) {
+function ifTopLevelReportWith(context: Rule.RuleContext) {
   return (node: Rule.Node) => {
     if (isTopLevel(node)) {
       context.report({
@@ -61,10 +61,10 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
           }
         }
       },
-      IfStatement: sideEffect(context),
-      ForStatement: sideEffect(context),
-      WhileStatement: sideEffect(context),
-      SwitchStatement: sideEffect(context)
+      IfStatement: ifTopLevelReportWith(context),
+      ForStatement: ifTopLevelReportWith(context),
+      WhileStatement: ifTopLevelReportWith(context),
+      SwitchStatement: ifTopLevelReportWith(context)
     };
   }
 };

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -62,15 +62,17 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
     return {
       ExpressionStatement: (node) => {
         if (isTopLevel(node)) {
-          if (isExportsAssignment(node)) return;
-          if (isExportPropertyAssignment(node)) return;
-          if (isIIFE(node)) return;
-          if (isModuleAssignment(node)) return;
-
-          context.report({
-            node,
-            messageId: 'message'
-          });
+          if (
+            !isExportsAssignment(node) &&
+            !isExportPropertyAssignment(node) &&
+            !isIIFE(node) &&
+            !isModuleAssignment(node)
+          ) {
+            context.report({
+              node,
+              messageId: 'message'
+            });
+          }
         }
       },
       IfStatement: ifTopLevelReportWith(context),


### PR DESCRIPTION
## Summary

Update the [no-top-level-side-effects](https://github.com/ericcornelissen/eslint-plugin-top/blob/cbddf80b87dd6267c8b2831d939ef5fdb803fa64/docs/rules/no-top-level-side-effect.md) rule implementation in an effort to improve readability and maintainability.