### PR TITLE
Report on top-level do-while statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - (`64781ae`) Improve performance of `no-top-level-side-effect`.
+- (`27d457b`) Report top-level do-while statements.
 
 ## [0.2.1] - 2022-12-13
 

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -76,6 +76,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       IfStatement: sideEffect(context),
       ForStatement: sideEffect(context),
       WhileStatement: sideEffect(context),
+      DoWhileStatement: sideEffect(context),
       SwitchStatement: sideEffect(context)
     };
   }

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -114,6 +114,15 @@ const invalid: RuleTester.InvalidTestCase[] = [
       notExports.foobar = {};
     `,
     errors
+  },
+  {
+    code: `
+      do {
+        i++;
+        s += i;
+      } while (i<10);
+    `,
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #206

## Summary

Let [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/9909b77bb9bc5c0d10a1f13a581d13e66b25e212/docs/rules/no-top-level-side-effect.md) rule report on `do`-`while` statements.