### PR TITLE
Report on top-level for-of statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`16462ae`) Report top-level for-of statements.
 
 ## [0.2.2] - 2022-12-30
 

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -77,6 +77,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       },
       IfStatement: ifTopLevelReportWith(context),
       ForStatement: ifTopLevelReportWith(context),
+      ForOfStatement: ifTopLevelReportWith(context),
       WhileStatement: ifTopLevelReportWith(context),
       DoWhileStatement: ifTopLevelReportWith(context),
       SwitchStatement: ifTopLevelReportWith(context)

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -123,6 +123,14 @@ const invalid: RuleTester.InvalidTestCase[] = [
       } while (i<10);
     `,
     errors
+  },
+  {
+    code: `
+      for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+        s += i;
+      }
+    `,
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #214 

## Summary

Let [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/cbd2ec509b40d84614b7577fcb54b9320c416643/docs/rules/no-top-level-side-effect.md) rule report on `for`-`of` statements.