### PR TITLE
Report on top-level for-in statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`e97db34`) Report top-level for-in statements.
 - (`16462ae`) Report top-level for-of statements.
 
 ## [0.2.2] - 2022-12-30

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -77,6 +77,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       },
       IfStatement: ifTopLevelReportWith(context),
       ForStatement: ifTopLevelReportWith(context),
+      ForInStatement: ifTopLevelReportWith(context),
       WhileStatement: ifTopLevelReportWith(context),
       DoWhileStatement: ifTopLevelReportWith(context),
       SwitchStatement: ifTopLevelReportWith(context)

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -123,6 +123,14 @@ const invalid: RuleTester.InvalidTestCase[] = [
       } while (i<10);
     `,
     errors
+  },
+  {
+    code: `
+      for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+        s += i;
+      }
+    `,
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #213

## Summary

Let [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/d44ba908093683d25c05a7aadeb1cb3fe6bc568a/docs/rules/no-top-level-side-effect.md) rule report on `for`-`of` statements.