### PR TITLE
Remove unnecessary check for top-level expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning].
 ## [Unreleased]
 
 - (`16462ae`) Report top-level for-of statements.
+- (`dc5f99e`) Improve performance of `no-top-level-side-effect`.
 
 ## [0.2.2] - 2022-12-30
 

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -36,7 +36,6 @@ function isExportPropertyAssignment(node: ExpressionStatement): boolean {
 function isIIFE(node: ExpressionStatement): boolean {
   return (
     node.expression.type === 'CallExpression' &&
-    node.expression.callee &&
     (node.expression.callee.type === 'ArrowFunctionExpression' ||
       node.expression.callee.type === 'FunctionExpression')
   );


### PR DESCRIPTION
Relates to #204

## Summary

Update the [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/96389efeb2d3896b2ebaf0a9766174ea1b6c7639/docs/rules/no-top-level-side-effect.md) rule implementation to remove an unnecessary truthiness check for IIFE expressions. This provides a slight performance improvement as it's one less expression to evaluate for top-level expressions.
