### PR TITLE
Report on top-level throw statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 
 - (`e97db34`) Report top-level for-in statements.
 - (`16462ae`) Report top-level for-of statements.
+- (`0a3ba0f`) Report top-level throw statements.
 - (`dc5f99e`) Improve performance of `no-top-level-side-effect`.
 
 ## [0.2.2] - 2022-12-30

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -81,7 +81,8 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       ForOfStatement: ifTopLevelReportWith(context),
       WhileStatement: ifTopLevelReportWith(context),
       DoWhileStatement: ifTopLevelReportWith(context),
-      SwitchStatement: ifTopLevelReportWith(context)
+      SwitchStatement: ifTopLevelReportWith(context),
+      ThrowStatement: ifTopLevelReportWith(context)
     };
   }
 };

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -139,6 +139,12 @@ const invalid: RuleTester.InvalidTestCase[] = [
       }
     `,
     errors
+  },
+  {
+    code: `
+      throw new Error('Hello world!');
+    `,
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #209 

## Summary

Let [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/0d168d86fba9336049950a2cf2b8981415e280b5/docs/rules/no-top-level-side-effect.md) rule report on `throw` statements.