### PR TITLE
Report on top-level try statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 - (`e97db34`) Report top-level for-in statements.
 - (`16462ae`) Report top-level for-of statements.
 - (`0a3ba0f`) Report top-level throw statements.
+- (`0fb75fa`) Report top-level try statements.
 - (`dc5f99e`) Improve performance of `no-top-level-side-effect`.
 
 ## [0.2.2] - 2022-12-30

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -81,7 +81,8 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       WhileStatement: ifTopLevelReportWith(context),
       DoWhileStatement: ifTopLevelReportWith(context),
       SwitchStatement: ifTopLevelReportWith(context),
-      ThrowStatement: ifTopLevelReportWith(context)
+      ThrowStatement: ifTopLevelReportWith(context),
+      TryStatement: ifTopLevelReportWith(context)
     };
   }
 };

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -145,6 +145,18 @@ const invalid: RuleTester.InvalidTestCase[] = [
       throw new Error('Hello world!');
     `,
     errors
+  },
+  {
+    code: `
+      try { } catch (e) { }
+    `,
+    errors
+  },
+  {
+    code: `
+      try { } catch (e) { } finally { }
+    `,
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #212 

## Summary

Let [no-top-level-side-effect](https://github.com/ericcornelissen/eslint-plugin-top/blob/96f479c06f0cdcfe039e05e1192053e911b3bc2b/docs/rules/no-top-level-side-effect.md) rule report on `try`-`catch` and `try`-`catch`-`finally` statements.