### PR TITLE
Update violation message wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning].
 - (`0a3ba0f`) Report top-level throw statements.
 - (`0fb75fa`) Report top-level try statements.
 - (`dc5f99e`) Improve performance of `no-top-level-side-effect`.
+- (`2e367d4`) Improve violation messaging.
 
 ## [0.2.2] - 2022-12-30
 

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -3,7 +3,7 @@ import type {ExpressionStatement} from 'estree';
 
 import {isTopLevel} from '../helpers';
 
-const violationMessage = 'Side effects in toplevel are not allowed';
+const violationMessage = 'Side effects at the top level are not allowed';
 
 function ifTopLevelReportWith(context: Rule.RuleContext) {
   return (node: Rule.Node) => {

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -3,7 +3,7 @@ import type {Expression, CallExpression, VariableDeclarator} from 'estree';
 
 import {isTopLevel} from '../helpers';
 
-const violationMessage = 'Unexpected variable at the top level';
+const violationMessage = 'Variables at the top level are not allowed';
 
 const constAllowedValues = ['Literal', 'MemberExpression'];
 const kindValues = ['const', 'let', 'var'];

--- a/tests/compat/snapshots.ts
+++ b/tests/compat/snapshots.ts
@@ -10,7 +10,7 @@ export const snapshots: ReadonlyArray<Snapshot> = [
     inp: 'var foo = "bar";',
     out: `
 <text>
-  1:5  error  Unexpected variable at the top level  @ericcornelissen/top/no-top-level-variables
+  1:5  error  Variables at the top level are not allowed  @ericcornelissen/top/no-top-level-variables
 
 ✖ 1 problem (1 error, 0 warnings)
 
@@ -21,7 +21,7 @@ export const snapshots: ReadonlyArray<Snapshot> = [
     inp: 'console.log("hello world");',
     out: `
 <text>
-  1:1  error  Side effects in toplevel are not allowed  @ericcornelissen/top/no-top-level-side-effect
+  1:1  error  Side effects at the top level are not allowed  @ericcornelissen/top/no-top-level-side-effect
 
 ✖ 1 problem (1 error, 0 warnings)
 


### PR DESCRIPTION
## Summary

Update the violation message of both the [`no-top-level-variables`](https://github.com/ericcornelissen/eslint-plugin-top/blob/2dbb34343e57e8a470c4ba78142912ee21389041/docs/rules/no-top-level-variables.md) rule and the [`no-top-level-side-effect`](https://github.com/ericcornelissen/eslint-plugin-top/blob/2dbb34343e57e8a470c4ba78142912ee21389041/docs/rules/no-top-level-side-effect.md) rule to make the wording consistent throughout the plugin.