### PR TITLE
Split `publish.yml` workflow into distinct jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,27 +7,17 @@ on:
 permissions: read-all
 
 jobs:
-  publish:
-    name: Publish
+  check:
+    name: Check
     runs-on: ubuntu-22.04
-    environment:
-      name: npm
-      url: https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top
-    permissions:
-      contents: write # To push a tag
+    outputs:
+      released: ${{ steps.version.outputs.released }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0 # To obtain all tags
-      - name: Install Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          cache: npm
-          node-version-file: .nvmrc
-          registry-url: https://registry.npmjs.org
-      - name: Install dependencies
-        run: npm clean-install
       - name: Check if version is released
         id: version
         run: |
@@ -38,27 +28,56 @@ jobs:
           else
             echo 'released=false' >> "$GITHUB_OUTPUT"
           fi
+  git:
+    name: git
+    runs-on: ubuntu-22.04
+    if: ${{ needs.check.outputs.released == 'false' }}
+    needs:
+      - check
+    permissions:
+      contents: write # To push refs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          fetch-depth: 0 # To fetch all major version branches
       - name: Get major version
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
-        if: ${{ steps.version.outputs.released == 'false' }}
         id: major-version
         with:
           result-encoding: string
           script: |
-            const version = "${{ steps.version.outputs.version }}"
+            const version = "${{ needs.check.outputs.version }}"
             const major = version.replace(/\.\d\.\d$/, "")
             return major
       - name: Publish git tag
-        if: ${{ steps.version.outputs.released == 'false' }}
         run: |
-          git tag '${{ steps.version.outputs.version }}'
-          git push origin '${{ steps.version.outputs.version }}'
+          git tag '${{ needs.check.outputs.version }}'
+          git push origin '${{ needs.check.outputs.version }}'
       - name: Update major version branch
-        if: ${{ steps.version.outputs.released == 'false' }}
         run: |
           git push origin 'HEAD:${{ steps.major-version.outputs.result }}'
+  npm:
+    name: npm
+    runs-on: ubuntu-22.04
+    if: ${{ needs.check.outputs.released == 'false' }}
+    needs:
+      - check
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+      - name: Install dependencies
+        run: npm clean-install
       - name: Publish to npm
-        if: ${{ steps.version.outputs.released == 'false' }}
         run: |
           npm publish
         env:


### PR DESCRIPTION
Relates to #145, #147

## Summary

Update the `publish.yml` workflow to separate the "release check", "git tag and branch update", and "publish to npm" jobs. Amongst other benefits, most notably, this further reduces the scope of the `NPM_TOKEN` secret.