### PR TITLE
Configure audit exceptions using GitHub Security Advisory IDs

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1081884": {
+  "GHSA-ww39-953v-wcq6": {
     "active": true,
     "notes": "ReDoS introduced through transitive dependency of ESLint@6. Since ESLint@6 is only used for compatibility testing the risk is accepted"
   }


### PR DESCRIPTION
Relates to #18

## Summary

Update the `.nsprc` configuration file (for [better-npm-audit]) to use GitHub Security Advisory IDs to identify vulnerabilities to ignore. This is instead of the previously used Node Security IDs which appear to be not-so static based on experiences in different projects: the Node Security ID for a given CVE/GHSA changed overnight.

**EDIT:** This has now also been observed in this project, see https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/3891173040/jobs/6641087826

[better-npm-audit]: https://www.npmjs.com/package/better-npm-audit