### PR TITLE
Support disallowing top-level IIFE with no-top-level-side-effect rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`a85b514`) Add support for configuring if top-level Immediately Invoked
+  Function Expressions (IIFEs) are allowed for `no-top-level-side-effect`.
 
 ## [0.2.3] - 2022-12-31
 

--- a/docs/rules/no-top-level-side-effect.md
+++ b/docs/rules/no-top-level-side-effect.md
@@ -78,6 +78,21 @@ module.exports = () => {
 })();
 ```
 
+### Options
+
+```yml
+rules:
+  '@ericcornelissen/top/no-top-side-effect':
+    - error
+    - allowIIFE: false
+```
+
+#### allowIIFE
+
+Allows or disallow top-level Immediate Invoked Function Expressions (IIFEs).
+
+Default is: `true`
+
 ## When Not To Use It
 
 If you want to allow top level side effects.

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -68,6 +68,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
     ]
   },
   create: (context) => {
+    // type-coverage:ignore-next-line
     const providedAllowIIFE: boolean | null = context.options[0]?.allowIIFE;
 
     const options: {

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -55,16 +55,41 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
     type: 'problem',
     messages: {
       message: violationMessage
-    }
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowIIFE: {
+            type: 'boolean'
+          }
+        }
+      }
+    ]
   },
   create: (context) => {
+    const providedAllowIIFE: boolean | null = context.options[0]?.allowIIFE;
+
+    const options: {
+      readonly allowIIFE: boolean;
+    } = {
+      allowIIFE:
+        typeof providedAllowIIFE === 'boolean' ? providedAllowIIFE : true
+    };
+
     return {
       ExpressionStatement: (node) => {
         if (isTopLevel(node)) {
-          if (
+          if (isIIFE(node)) {
+            if (!options.allowIIFE) {
+              context.report({
+                node,
+                messageId: 'message'
+              });
+            }
+          } else if (
             !isExportsAssignment(node) &&
             !isExportPropertyAssignment(node) &&
-            !isIIFE(node) &&
             !isModuleAssignment(node)
           ) {
             context.report({

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -157,6 +157,32 @@ const invalid: RuleTester.InvalidTestCase[] = [
       try { } catch (e) { } finally { }
     `,
     errors
+  },
+  {
+    code: `
+      (function() {
+        return '';
+      })();
+    `,
+    options: [
+      {
+        allowIIFE: false
+      }
+    ],
+    errors
+  },
+  {
+    code: `
+      (() => {
+        return '';
+      })();
+    `,
+    options: [
+      {
+        allowIIFE: false
+      }
+    ],
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #205 

## Summary

Add support for disallowing top-level [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) with [`no-top-level-side-effect` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/4856b2a83652936bcf08ba46199dfdf1672ae9d0/docs/rules/no-top-level-side-effect.md) through an option. The default behaviour stays as is, i.e. by default top-level IIFE are allowed.