### PR TITLE
Improve `no-top-level-variables` rule documentation

### DIFF
--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -16,24 +16,20 @@ This rule lets you control top level variable assignments.
 Examples of **incorrect** code for this rule:
 
 ```javascript
-var foo = 42;
-const bar = new Array();
-let baz = 0;
-
-// Rest of your code
+var answer = 42;
+let foo = 'bar';
+const list = new Array();
 ```
 
 Examples of **correct** code for this rule:
 
 ```javascript
-const bar = 1337;
+const leet = 1337;
 
 export default function () {
-  var foo = 42;
-  const bar = new Array();
-  let baz = 0;
-
-  // Rest of your code
+  var answer = 42;
+  let foo = 'bar';
+  const list = new Array();
 }
 ```
 
@@ -51,7 +47,7 @@ This rule accepts a configuration object with two options:
 Examples of **correct** code when `'Literal'` is allowed:
 
 ```javascript
-const foo = 42;
+const answer = 42;
 const hello = 'world!';
 const NULL = null;
 ```

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -51,11 +51,50 @@ Allows to customize what kinds of assignments are allowed for `const`.
 
 Default is: `["Literal", "MemberExpression"]`
 
+Examples of **correct** code when `'Literal'` is allowed:
+
+```javascript
+const foo = 42;
+const hello = 'world!';
+const NULL = null;
+```
+
+Examples of **correct** code when `'MemberExpression'` is allowed:
+
+```javascript
+const parse = JSON.parse;
+const map = Array.prototype.map;
+```
+
 #### kind
 
 Allows to only forbid specific kinds of variables.
 
 Default is: `["const", "let", "var"]`
+
+Examples of **correct** code when `'const'` is not in the list:
+
+```javascript
+const answer = 42;
+const list = new Array();
+const foobar = JSON.parse('{"foo":"bar"}');
+```
+
+Examples of **correct** code when `'let'` is not in the list:
+
+```javascript
+let answer = 42;
+let list = new Array();
+let foobar = JSON.parse('{"foo":"bar"}');
+```
+
+Examples of **correct** code when `'var'` is not in the list:
+
+```javascript
+var answer = 42;
+var list = new Array();
+var foobar = JSON.parse('{"foo":"bar"}');
+```
 
 ## When Not To Use It
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -1,10 +1,17 @@
 # No top level variables (no-top-level-variables)
 
-Based on [eslint-plugin-toplevel].
+Disallow top level variables.
+
+Variables at the top level may indicate side effects. It may be initialized by
+means of a function call, which is a side effect. Or it may be used as state in
+the functions or methods of the module, which means it's used for side effects.
+
+As such, `const` is handled differently from `let` and `var` since it's value is
+not meant to be mutated.
 
 ## Rule Details
 
-Lets you disallow top level variables.
+This rule lets you control top level variable assignments.
 
 Examples of **incorrect** code for this rule:
 
@@ -32,24 +39,14 @@ export default function () {
 
 ### Options
 
-```yml
-rules:
-  '@ericcornelissen/top/no-top-level-variables':
-    - error
-    - constAllowed:
-        - Literal
-        - MemberExpression
-      kind:
-        - const
-        - let
-        - var
-```
+This rule accepts a configuration object with two options:
+
+- `constAllowed`: Configure what assignments are allowed for `const`. By default
+  literal and member expression assignments are allowed.
+- `kind`: Configure which kinds of variables are forbidden. By default all of
+  `const`, `let`, and `var` are forbidden.
 
 #### constAllowed
-
-Allows to customize what kinds of assignments are allowed for `const`.
-
-Default is: `["Literal", "MemberExpression"]`
 
 Examples of **correct** code when `'Literal'` is allowed:
 
@@ -67,10 +64,6 @@ const map = Array.prototype.map;
 ```
 
 #### kind
-
-Allows to only forbid specific kinds of variables.
-
-Default is: `["const", "let", "var"]`
 
 Examples of **correct** code when `'const'` is not in the list:
 
@@ -105,5 +98,4 @@ If you want to allow top level variables.
 Please [open an issue] if you found a mistake or if you have a suggestion for
 how to improve the documentation.
 
-[eslint-plugin-toplevel]: https://github.com/HKalbasi/eslint-plugin-toplevel
 [open an issue]: https://github.com/ericcornelissen/eslint-plugin-top/issues/new?labels=documentation&template=documentation.md

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -24,6 +24,16 @@ const list = new Array();
 Examples of **correct** code for this rule:
 
 ```javascript
+var fs = require('node:fs');
+let path = require('node:path');
+const util = require('node:util');
+```
+
+```javascript
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as util from 'node:util';
+
 const leet = 1337;
 
 export default function () {


### PR DESCRIPTION
Contributes to #249

## Summary

Update the documentation for the [`no-top-level-variables` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/75b24d42fd4f88e02e410ec5f5bbf0915aa8124a/docs/rules/no-top-level-variables.md) to be easier to use. Changes are based on ESLint base rule documentation. Improvements include:

- Add more examples, in particular for the options.
- Rewrite sentences and paragraphs for clarity and brevity.
- Re-ordering of content, in line with ESLint base rule documentation.