### PR TITLE
Update `no-top-level-variables` rule implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`92a3f58`) Improve performance of `no-top-level-variables`.
 
 ## [0.3.0] - 2023-01-13
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -49,8 +49,10 @@ export const noTopLevelVariables: Rule.RuleModule = {
 
     return {
       VariableDeclaration: (node) => {
-        const isMatching = Array.from(options.kind).includes(node.kind);
-        if (!isTopLevel(node) || !isMatching) {
+        if (
+          !isTopLevel(node) ||
+          !Array.from(options.kind).includes(node.kind)
+        ) {
           return;
         }
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -8,6 +8,10 @@ const violationMessage = 'Variables at the top level are not allowed';
 const constAllowedValues = ['Literal', 'MemberExpression'];
 const kindValues = ['const', 'let', 'var'];
 
+function isRequireCall(node: CallExpression): boolean {
+  return node.callee.type === 'Identifier' && node.callee.name === 'require';
+}
+
 export const noTopLevelVariables: Rule.RuleModule = {
   meta: {
     type: 'problem',
@@ -67,11 +71,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
             switch ((declaration.init as Expression).type) {
               case 'CallExpression': {
                 // type-coverage:ignore-next-line
-                const callExpression = declaration.init as CallExpression;
-                return (
-                  callExpression.callee.type === 'Identifier' &&
-                  callExpression.callee.name === 'require'
-                );
+                return isRequireCall(declaration.init as CallExpression);
               }
               case 'Literal':
                 return isLiteralAllowed;
@@ -84,8 +84,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
         } else {
           allowedDeclaration = (declaration) =>
             declaration.init?.type === 'CallExpression' &&
-            declaration.init.callee.type === 'Identifier' &&
-            declaration.init.callee.name === 'require';
+            isRequireCall(declaration.init);
         }
 
         node.declarations


### PR DESCRIPTION
Relates to #118

## Summary

If a variable declaration `!isTopLevel` there is no need to do any kind of check. As such, don't try to figure out if the `node.kind` (e.g. `var`) is being consider by the rule according to the options.

Also refactor out the duplicated logic related to recognizing `require()` calls.