### PR TITLE
Update `no-top-level-side-effect` rule implementation

### DIFF
--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -80,24 +80,26 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
 
     return {
       ExpressionStatement: (node) => {
-        if (isTopLevel(node)) {
-          if (isIIFE(node)) {
-            if (!options.allowIIFE) {
-              context.report({
-                node,
-                messageId: 'message'
-              });
-            }
-          } else if (
-            !isExportsAssignment(node) &&
-            !isExportPropertyAssignment(node) &&
-            !isModuleAssignment(node)
-          ) {
+        if (!isTopLevel(node)) {
+          return;
+        }
+
+        if (isIIFE(node)) {
+          if (!options.allowIIFE) {
             context.report({
               node,
               messageId: 'message'
             });
           }
+        } else if (
+          !isExportsAssignment(node) &&
+          !isExportPropertyAssignment(node) &&
+          !isModuleAssignment(node)
+        ) {
+          context.report({
+            node,
+            messageId: 'message'
+          });
         }
       },
       IfStatement: ifTopLevelReportWith(context),


### PR DESCRIPTION
## Summary

Refactor the [`no-top-level-side-effect` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/c47667ae522f823237f15f9591df0e50b64a241d/docs/rules/no-top-level-side-effect.md) implementation in order to reduce indentation.