### PR TITLE
Don't run optional linters with `npm run lint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "format": "npm run _prettier -- --write",
     "format:check": "npm run _prettier -- --check",
     "license-check": "licensee --errors-only",
-    "lint": "npm run lint:ci && npm run lint:json && npm run lint:md && npm run lint:ts && npm run lint:yml",
+    "lint": "npm run lint:json && npm run lint:md && npm run lint:ts && npm run lint:yml",
     "lint:ci": "actionlint",
     "lint:json": "npm run _eslint -- . --ext .json",
     "lint:md": "npm run lint:md:text && npm run lint:md:code",


### PR DESCRIPTION
Relates to #219

## Summary

Update the "lint" script definition to avoid running linters that are considered optional (per the Contributing Guidelines) so as the avoid this script failing unexpectedly if the linters aren't installed