### PR TITLE
Rename app/token for automation purposes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Create token to create Pull Request
+      - name: Create automation token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        id: release-token
+        id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Get latest version
         id: version
         run: |
@@ -49,7 +49,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
         with:
-          token: ${{ steps.release-token.outputs.token }}
+          token: ${{ steps.automation-token.outputs.token }}
           title: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
           body: |
             _This Pull Request was created automatically_

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Create token to create Pull Request
+      - name: Create automation token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        id: release-token
+        id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Bump version
         run: npm version '${{ github.event.inputs.update_type }}' --no-git-tag-version
       - name: Update CHANGELOG
@@ -43,7 +43,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
         with:
-          token: ${{ steps.release-token.outputs.token }}
+          token: ${{ steps.automation-token.outputs.token }}
           title: New ${{ github.event.inputs.update_type }} release
           body: |
             _This Pull Request was created automatically_


### PR DESCRIPTION
Relates to #145, #256

## Summary

Rename `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` to `AUTOMATION_APP_ID` and `AUTOMATION_APP_PRIVATE_KEY` (and related things) as these aren't used for release purposes exclusively.