### PR TITLE
Let `no-top-level-side-effect` report on IIFEs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`cec69d5`) _(Breaking)_ Report top-level IIFEs by default.
 - (`92a3f58`) Improve performance of `no-top-level-variables`.
 
 ## [0.3.0] - 2023-01-13

--- a/docs/rules/no-top-level-side-effect.md
+++ b/docs/rules/no-top-level-side-effect.md
@@ -67,12 +67,12 @@ module.exports = function () {
 
 This rule accepts a configuration object with one option:
 
-- `allowIIFE: true` (default) Configure whether top level Immediately Invoked
+- `allowIIFE: false` (default) Configure whether top level Immediately Invoked
   Function Expressions are allowed.
 
 #### allowIIFE
 
-Examples of **incorrect** code when set to `false`:
+Examples of **correct** code when set to `true`:
 
 ```javascript
 (function () {

--- a/lib/rules/no-top-level-side-effect.ts
+++ b/lib/rules/no-top-level-side-effect.ts
@@ -75,7 +75,7 @@ export const noTopLevelSideEffect: Rule.RuleModule = {
       readonly allowIIFE: boolean;
     } = {
       allowIIFE:
-        typeof providedAllowIIFE === 'boolean' ? providedAllowIIFE : true
+        typeof providedAllowIIFE === 'boolean' ? providedAllowIIFE : false
     };
 
     return {

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -9,14 +9,24 @@ const valid: RuleTester.ValidTestCase[] = [
       (function() {
         return '';
       })();
-    `
+    `,
+    options: [
+      {
+        allowIIFE: true
+      }
+    ]
   },
   {
     code: `
       (() => {
         return '';
       })();
-    `
+    `,
+    options: [
+      {
+        allowIIFE: true
+      }
+    ]
   },
   {
     code: `
@@ -164,11 +174,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
         return '';
       })();
     `,
-    options: [
-      {
-        allowIIFE: false
-      }
-    ],
     errors
   },
   {
@@ -177,11 +182,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
         return '';
       })();
     `,
-    options: [
-      {
-        allowIIFE: false
-      }
-    ],
     errors
   }
 ];

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -183,6 +183,17 @@ const invalid: RuleTester.InvalidTestCase[] = [
       })();
     `,
     errors
+  },
+  {
+    code: `
+      console.log('hello world');
+    `,
+    options: [
+      {
+        allowIIFE: true
+      }
+    ],
+    errors
   }
 ];
 


### PR DESCRIPTION
Closes #267
Relates to #241, #299

## Summary

Update the [`no-top-level-side-effect` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/896b639a3c2a683b6e016d2173375a0e86ce7646/docs/rules/no-top-level-side-effect.md) to disallow top-level Immediately Invoked Function Expressions (IIFEs) by default.