### PR TITLE
Rename `no-top-level-side-effect` to `no-top-level-side-effects`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning].
 
 ## [Unreleased]
 
+- (`9ddf3fe`) _(Breaking)_ Rename the rule `no-top-level-side-effect` to
+  `no-top-level-side-effects`.
 - (`92a3f58`) Improve performance of `no-top-level-variables`.
 
 ## [0.3.0] - 2023-01-13

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Then, configure the rules you want to use in the rules section:
 
 ```yml
 rules:
-  '@ericcornelissen/top/no-top-level-side-effect': error
+  '@ericcornelissen/top/no-top-level-side-effects': error
   '@ericcornelissen/top/no-top-level-variables': error
 ```
 
 ## Supported Rules
 
-- [`no-top-level-side-effect`]
+- [`no-top-level-side-effects`]
 - [`no-top-level-variables`]
 
 ---
@@ -46,5 +46,5 @@ how to improve the documentation.
 
 [eslint]: https://eslint.org/
 [open an issue]: https://github.com/ericcornelissen/eslint-plugin-top/issues/new?labels=documentation&template=documentation.md
-[`no-top-level-side-effect`]: docs/rules/no-top-level-side-effect.md
+[`no-top-level-side-effects`]: docs/rules/no-top-level-side-effects.md
 [`no-top-level-variables`]: docs/rules/no-top-level-variables.md

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -1,4 +1,4 @@
-# No top level side effect (no-top-level-side-effect)
+# No top level side effect (no-top-level-side-effects)
 
 Disallow top level side effects.
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import {noTopLevelSideEffect} from './rules/no-top-level-side-effect';
+import {noTopLevelSideEffects} from './rules/no-top-level-side-effects';
 import {noTopLevelVariables} from './rules/no-top-level-variables';
 
 /**
@@ -11,5 +11,5 @@ import {noTopLevelVariables} from './rules/no-top-level-variables';
  */
 export const rules = {
   'no-top-level-variables': noTopLevelVariables,
-  'no-top-level-side-effect': noTopLevelSideEffect
+  'no-top-level-side-effects': noTopLevelSideEffects
 };

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -50,7 +50,7 @@ function isModuleAssignment(node: ExpressionStatement): boolean {
   );
 }
 
-export const noTopLevelSideEffect: Rule.RuleModule = {
+export const noTopLevelSideEffects: Rule.RuleModule = {
   meta: {
     type: 'problem',
     messages: {

--- a/tests/compat/helpers.ts
+++ b/tests/compat/helpers.ts
@@ -28,7 +28,7 @@ export function runEslint(version: number, snippet: string): {stdout: string} {
       '--rule',
       '@ericcornelissen/top/no-top-level-variables: error',
       '--rule',
-      '@ericcornelissen/top/no-top-level-side-effect: error'
+      '@ericcornelissen/top/no-top-level-side-effects: error'
     ],
     {
       encoding: 'utf-8',

--- a/tests/compat/snapshots.ts
+++ b/tests/compat/snapshots.ts
@@ -21,7 +21,7 @@ export const snapshots: ReadonlyArray<Snapshot> = [
     inp: 'console.log("hello world");',
     out: `
 <text>
-  1:1  error  Side effects at the top level are not allowed  @ericcornelissen/top/no-top-level-side-effect
+  1:1  error  Side effects at the top level are not allowed  @ericcornelissen/top/no-top-level-side-effects
 
 ✖ 1 problem (1 error, 0 warnings)
 

--- a/tests/unit/no-top-level-side-effect.test.ts
+++ b/tests/unit/no-top-level-side-effect.test.ts
@@ -1,7 +1,7 @@
 import * as parser from '@typescript-eslint/parser';
 import {RuleTester} from 'eslint';
 import {trimTestCases} from './helpers';
-import {noTopLevelSideEffect} from '../../lib/rules/no-top-level-side-effect';
+import {noTopLevelSideEffects} from '../../lib/rules/no-top-level-side-effects';
 
 const valid: RuleTester.ValidTestCase[] = [
   {
@@ -192,7 +192,7 @@ new RuleTester({
     ecmaVersion: 2020,
     sourceType: 'module'
   }
-}).run('no-top-level-side-effect', noTopLevelSideEffect, {
+}).run('no-top-level-side-effects', noTopLevelSideEffects, {
   valid: valid.map(trimTestCases),
   invalid: invalid.map(trimTestCases)
 });


### PR DESCRIPTION
Closes #269
Relates to #299

## Summary

Rename `no-top-level-side-effect` to `no-top-level-side-effects` so that, like `no-top-level-variables`, it's plural.