### PR TITLE
Update license compliance configuration

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -3,6 +3,7 @@
     "spdx": [
       "0BSD",
       "Apache-2.0",
+      "BlueOak-1.0.0",
       "BSD-2-Clause",
       "BSD-3-Clause",
       "CC0-1.0",


### PR DESCRIPTION
Relates to #76, #343

## Summary

Allow (preemptively) the v1 of the [Blue Oak license] for dependencies. This is a permissive license with minimal requirements, similar to the (already allowed) Apache 2 license.

It's added preemptively as it's been observed in transitive dependencies of (at least) v2.1.3 of [`knip`](https://github.com/ericcornelissen/eslint-plugin-top/blob/417929e15aaf6daf6289149dc3e82fa52e4b9fe8/package.json#L53) and v6.4.2 of [`@stryker-mutator/core`](https://github.com/ericcornelissen/eslint-plugin-top/blob/417929e15aaf6daf6289149dc3e82fa52e4b9fe8/package.json#L35).

[Blue Oak license]: https://blueoakcouncil.org/license/1.0.0