### PR TITLE
Reduce availability scope of the `SEMGREP_APP_TOKEN` secret

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -176,8 +176,6 @@ jobs:
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: returntocorp/semgrep
     steps:
@@ -185,6 +183,8 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform Semgrep analysis
         run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
   test:
     name: Test
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #313

## Summary

Only make the `SEMGREP_APP_TOKEN` available in the job step that needs it, as opposed to the whole job. Following the principle of least privilege.