### PR TITLE
Document reason for elevated permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
     needs:
       - build
     permissions:
-      security-events: write
+      security-events: write # To upload CodeQL results
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1


### PR DESCRIPTION
Closes #346

## Summary

Add a comment with an explanation for the reason of any elevated permissions in GitHub Actions workflows where it was not already present.