### PR TITLE
Set up `actions/labeler`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Check out Labeler at: https://github.com/actions/labeler
+
+ci:
+  - .github/workflows/*
+  - .github/codecov.yml
+  - .github/codeql.yml
+  - .github/dependabot.yml
+  - .github/labeler.yml
+
+dependencies:
+  - .tool-versions
+  - package-lock.json
+
+documentation:
+  - docs/*
+  - README.md
+
+test:
+  - tests/**
+  - tests/**/*
+
+security:
+  - SECURITY.md

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: Labeler
+on:
+  pull_request_target: ~
+
+permissions: read-all
+
+jobs:
+  label:
+    name: Label
+    permissions:
+      pull-requests: write # To assign labels
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+      - name: Set labels on Pull Request
+        uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: ''


### PR DESCRIPTION
## Summary

Create a new GitHub Actions workflow dedicated to the [`actions/labeler`](https://github.com/actions/labeler) Action. This Action aims to automatically apply labels to Pull Requests based on what files have been changed, slightly reducing manual effort required. It is configured with an initial rule set of labels for some files - this may grow/change over time.
