### PR TITLE
Publish with provenance from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,8 @@ jobs:
     if: ${{ needs.check.outputs.released == 'false' }}
     needs:
       - check
+    permissions:
+      id-token: write # To attach provenance to the published package
     environment:
       name: npm
       url: https://www.npmjs.com/package/@ericcornelissen/eslint-plugin-top
@@ -107,6 +109,6 @@ jobs:
         run: npm clean-install
       - name: Publish to npm
         run: |
-          npm publish
+          npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Relates to #145

## Summary

Update the CI-based publishing strategy for this project to use the new `--provenance` option - setup based on the [official npm docs on the provenance](https://docs.npmjs.com/generating-provenance-statements).

The goal here is to increase linkability between the npm package and the GitHub repository as well as the specific commit and CI workflow that resulted in a specific version.
