### PR TITLE
Update `publish.yml` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            nodejs.org:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
       - name: Checkout repository


### PR DESCRIPTION
Relates to #378, #381

## Summary

Update the "Publish / npm" job's egress policy to allow for downloading Node.js if necessary.