### PR TITLE
Update `publish.yml` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,6 +110,6 @@ jobs:
         run: npm clean-install
       - name: Publish to npm
         run: |
-          npm publish --provenance
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Relates to #381, #382

## Summary

Update the "Publish / npm" job to explicitly set `--access public` following the example workflow seen in: https://docs.npmjs.com/generating-provenance-statements