### PR TITLE
Update `publish.yml` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,13 +91,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install Node.js


### PR DESCRIPTION
Relates to #379, #381, #382, #383

## Summary

Update the "Publish / npm" job to revert harden-runner back to auditing following the introduction of the `--provenance` flag on `npm publish`, which introduces various new outbound requests.
