### PR TITLE
Bump yaml from 2.1.3 to 2.2.2 (for `main-v0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9935,9 +9935,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"


### PR DESCRIPTION
Relates to #396

## Summary

Bump transitive dependency `yaml` from 2.1.3 to 2.2.2 because of [CVE-2023-2251](https://github.com/advisories/GHSA-f9xv-q969-pqx4), this time for the `main-v0` branch.

It's a development dependency only, so no release is necessary.