### PR TITLE
Use `node:` imports in compatibility test code

### DIFF
--- a/tests/compat/helpers.ts
+++ b/tests/compat/helpers.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ISC
 
-import * as cp from 'child_process';
-import * as path from 'path';
+import * as cp from 'node:child_process';
+import * as path from 'node:path';
 
 export function runEslint(version: number, snippet: string): {stdout: string} {
   const projectRoot = path.resolve('.');

--- a/tests/compat/main.test.ts
+++ b/tests/compat/main.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: ISC
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 import {runEslint} from './helpers';
 import {snapshots} from './snapshots';


### PR DESCRIPTION
Closes #21
Relates to #443

## Summary

Use `node:` imports in compatibility test code.