### PR TITLE
Update export metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Disallow side effects at the top level of files",
   "version": "1.0.1",
   "license": "ISC",
-  "main": "index.js",
   "exports": "./index.js",
   "engines": {
     "node": "18.x || 20.x"


### PR DESCRIPTION
Closes #30
Relates to #443

## Summary

Drop `package.json#main` in favor of `package.json#exports`, based on the [Node.js v18 documentation for `package.json`](https://nodejs.org/docs/latest-v18.x/api/packages.html#nodejs-packagejson-field-definitions).