### PR TITLE
Deduplicate the compatibility testing command

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lint:yml": "npm run _eslint -- . --ext .yml",
     "test": "mocha tests/unit --recursive",
     "test:compat": "mocha tests/compat --recursive",
-    "test:compat-all": "nve 18.0.0,20.0.0 mocha tests/compat --recursive",
+    "test:compat-all": "nve 18.0.0,20.0.0 npm run test:compat --ignore-scripts",
     "test:mutation": "stryker run stryker.config.js",
     "test:watch": "npm run test -- --watch",
     "verify": "npm run build && npm run format:check && npm run lint && npm run test && npm run vet",


### PR DESCRIPTION
Relates to #443, #444

## Summary

Avoid the repetition of the compatibility testing command between `test:compat` and `test:compat-all` by simply invoking `test:compat` (with the npm option `--ignore-scripts` to avoid unnecessarily rebuilding).