### PR TITLE
Set `retention-days` for index-js artifact

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           name: index-js
           path: index.js
+          retention-days: 1
   codeql:
     name: CodeQL
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #97

## Summary

The artifact is only intended for re-use across jobs. As such, it can be deleted as soon as the workflow ends/possible.

See also [the `actions/upload-artifact` docs on Retention Period](https://github.com/actions/upload-artifact/tree/65d862660abb392b8c4a3d1195a2108db131dd05#retention-period).