### PR TITLE
Replace homegrown tooling updates by dedicated action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,17 +13,11 @@ jobs:
     with:
       refs: '["main", "main-v1", "v1", "v2"]'
   tooling:
-    name: Tool update ${{ matrix.tool }}
+    name: Update tooling
     runs-on: ubuntu-22.04
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
-    strategy:
-      fail-fast: false
-      matrix:
-        tool:
-          - actionlint
-          - shellcheck
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
@@ -31,43 +25,18 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
       - name: Create automation token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         id: automation-token
         with:
           app_id: ${{ secrets.AUTOMATION_APP_ID }}
           private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-      - name: Get latest version
-        id: version
-        run: |
-          LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
-          echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-      - name: Install new version
-        run: |
-          asdf install '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
-      - name: Apply latest version to .tool-versions
-        run: |
-          asdf local '${{ matrix.tool }}' '${{ steps.version.outputs.latest }}'
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action/pr@479c41ef190561c39ed9b0c1cb43c102084f1fc9 # v0.2.0
         with:
+          max: 1
           token: ${{ steps.automation-token.outputs.token }}
-          title: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
-          body: |
-            _This Pull Request was created automatically_
-
-            ---
-
-            Bump ${{ matrix.tool }} to v${{ steps.version.outputs.latest }}
-          branch: asdf-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
-          labels: dependencies
-          commit-message: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
-          add-paths: |
-            .tool-versions


### PR DESCRIPTION
Closes #238
Relates to #210

## Summary

Replace homegrown tooling updates by a dedicated action: [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action)