### PR TITLE
Ignore GHSA-c2qf-rxjj-qqgw when auditing

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,6 @@
 {
+  "GHSA-c2qf-rxjj-qqgw": {
+    "active": true,
+    "notes": "ReDoS in various devDependency trees with limited impact. Updates should come in over time."
+  }
 }


### PR DESCRIPTION
## Summary

The dependency introducing GHSA-c2qf-rxjj-qqgw is only present through development dependencies and there this vulnerability has limited impact. No fix is presently available, but all packages that use a vulnerable version of the package have bug tracking tickets open to address the problem. So, it is expected that the dependency on this vulnerable version will disappear over time with [Dependabot updates](https://github.com/ericcornelissen/eslint-plugin-top/pulls?q=is%3Apr+author%3Aapp%2Fdependabot).