### PR TITLE
Ignore GHSA-c2qf-rxjj-qqgw when auditing for v1 maintenance branch

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,5 +2,9 @@
   "GHSA-ww39-953v-wcq6": {
     "active": true,
     "notes": "ReDoS introduced through transitive dependency of ESLint@6. Since ESLint@6 is only used for compatibility testing the risk is accepted"
+  },
+  "GHSA-c2qf-rxjj-qqgw": {
+    "active": true,
+    "notes": "ReDoS in various devDependency trees with limited impact. Updates may come in over time."
   }
 }


### PR DESCRIPTION
Relates to #483

## Summary

The dependency introducing GHSA-c2qf-rxjj-qqgw is only present through development dependencies and there this vulnerability has limited impact. For the v1 maintenance branch I don't intent on actively trying to update dependencies that introduce this vulnerability into the dependency tree, but will gladly accept any externally contributed Pull Requests that do update said dependencies.