### PR TITLE
Move CI auditing into separate workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Audit
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+      - v2
+
+permissions: read-all
+
+jobs:
+  audit:
+    name: Audit
+    uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,9 +11,6 @@ on:
 permissions: read-all
 
 jobs:
-  audit:
-    name: Audit
-    uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main
   build:
     name: Build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Separate the continuous audit job from the general checks workflow. The motivation for this is that checks should always pass (similar to `npm run verify`), but audit may not always be passing and this is not always a problem.