### PR TITLE
Set up weekly CI job to update transitive dependencies

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,43 @@
+name: Weekly
+on:
+  schedule:
+    - cron: '0 4 * * 6'
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  npm-deps:
+    name: Update transitive dependencies
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # To push a commit
+      pull-requests: write # To open a Pull Request
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+        with:
+          egress-policy: audit
+      - name: Create automation token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        id: automation-token
+        with:
+          app_id: ${{ secrets.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+      - name: Update dependencies
+        run: npm update
+      - name: Dedupe dependencies
+        run: npm dedupe
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          token: ${{ steps.automation-token.outputs.token }}
+          title: Update transitive dependencies
+          body: |
+            _This Pull Request was created automatically_
+          branch: npm-transitive-dependencies
+          labels: dependencies
+          commit-message: Update transitive dependencies
+          add-paths: |
+            package.json
+            package-lock.json


### PR DESCRIPTION
Relates to #380, #430, #474

## Summary

Create a new GitHub Actions workflow/job to update all transitive dependencies on a weekly basis by running `npm update` (and `npm dedupe`) and creating a Pull Request for the resulting changes.

This is experimental; intended to see if and how it works and if there's any noticeable benefits.