### PR TITLE
Configure initial update groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       time: '05:00'
     labels:
       - dependencies
+    groups:
+      stryker:
+        patterns:
+          - '@stryker-mutator/*'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

Configure two `groups` per the ["Grouped version updates for Dependabot public beta" blogpost](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) to streamline dependency updates by Dependabot.

The first group is aimed at the Stryker dependencies, they are always released together and in the past this project has experienced a lack of updates in this area (seemingly because of interconnected dependency requirements).

The seconds is aimed at the TypeScript ESLint dependencies, while there haven't been any problems in the past, this will reduce the number of updates received as these updates are also always released together.
