### PR TITLE
Fix verbose logging for `format:check` in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Check formatting
-        run: npm run format:check -- --loglevel debug
+        run: npm run format:check -- --log-level debug
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #242, #512

## Summary

Update Prettier invocation to use the new v3 `--log-level` instead of the old v2 `--loglevel`