### PR TITLE
Specialize config check CI workflow

### DIFF
--- a/.github/workflows/config-codecov.yml
+++ b/.github/workflows/config-codecov.yml
@@ -1,15 +1,15 @@
-name: Config
+name: Config Codecov
 on:
   pull_request:
     paths:
-      - .github/workflows/check-config.yml
+      - .github/workflows/config-codecov.yml
       - .github/codecov.yml
   push:
     branches:
       - main
       - main-v1
     paths:
-      - .github/workflows/check-config.yml
+      - .github/workflows/config-codecov.yml
       - .github/codecov.yml
 
 permissions: read-all


### PR DESCRIPTION
Relates to #112, #151

## Summary

Update the CI workflow for validating the Codecov configuration from being framed as a "general config check workflow" to a specific "Codecov config check workflow". The main aim of this change is to avoid, in the future, running the Codecov configuration check when another config file that is continuously validated is changed. This wastes resources and puts unnecessary load on the Codecov API.