### PR TITLE
Add support for allowing for top-level assignment of arrow functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`8a7eb63`) Allow top-level assignments of arrow functions to `const`.
 
 ## [2.0.0] - 2023-06-03
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -48,11 +48,18 @@ export default function () {
 This rule accepts a configuration object with two options:
 
 - `constAllowed`: Configure what assignments are allowed for `const`. By default
-  literal and member expression assignments are allowed.
+  arrow functions, literals, and member expression assignments are allowed.
 - `kind`: Configure which kinds of variables are forbidden. By default all of
   `const`, `let`, and `var` are forbidden.
 
 #### constAllowed
+
+Examples of **correct** code when `'ArrowFunctionExpression'` is allowed:
+
+```javascript
+const answer = () => 42;
+const hello = (name) => `Hello ${name}!`;
+```
 
 Examples of **correct** code when `'Literal'` is allowed:
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -7,7 +7,11 @@ import {isTopLevel} from '../helpers';
 
 const violationMessage = 'Variables at the top level are not allowed';
 
-const constAllowedValues = ['Literal', 'MemberExpression'];
+const constAllowedValues = [
+  'ArrowFunctionExpression',
+  'Literal',
+  'MemberExpression'
+];
 const kindValues = ['const', 'let', 'var'];
 
 function isRequireCall(node: CallExpression): boolean {
@@ -64,6 +68,9 @@ export const noTopLevelVariables: Rule.RuleModule = {
 
         let allowedDeclaration: (declaration: VariableDeclarator) => boolean;
         if (node.kind === 'const') {
+          const isArrowFunctionAllowed = options.constAllowed.includes(
+            'ArrowFunctionExpression'
+          );
           const isLiteralAllowed = options.constAllowed.includes('Literal');
           const isMemberExpressionAllowed =
             options.constAllowed.includes('MemberExpression');
@@ -71,6 +78,8 @@ export const noTopLevelVariables: Rule.RuleModule = {
           allowedDeclaration = (declaration) => {
             // type-coverage:ignore-next-line
             switch ((declaration.init as Expression).type) {
+              case 'ArrowFunctionExpression':
+                return isArrowFunctionAllowed;
               case 'CallExpression': {
                 // type-coverage:ignore-next-line
                 return isRequireCall(declaration.init as CallExpression);

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -78,6 +78,21 @@ const valid: RuleTester.ValidTestCase[] = [
         constAllowed: ['MemberExpression']
       }
     ]
+  },
+  {
+    code: `
+      const foo = () => 'bar';
+    `
+  },
+  {
+    code: `
+      const foo = () => 'bar';
+    `,
+    options: [
+      {
+        constAllowed: ['ArrowFunctionExpression']
+      }
+    ]
   }
 ];
 
@@ -351,6 +366,25 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     options: [
       {
+        constAllowed: ['ArrowFunctionExpression']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 30
+      }
+    ]
+  },
+  {
+    code: `
+      const isArray = Array.isArray;
+    `,
+    options: [
+      {
         constAllowed: ['Literal']
       }
     ],
@@ -361,6 +395,25 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 30
+      }
+    ]
+  },
+  {
+    code: `
+      const pi = 3.14;
+    `,
+    options: [
+      {
+        constAllowed: ['ArrowFunctionExpression']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 16
       }
     ]
   },
@@ -394,6 +447,72 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 5,
         endLine: 1,
         endColumn: 16
+      }
+    ]
+  },
+  {
+    code: `
+      var foo = () => 'bar';
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 22
+      }
+    ]
+  },
+  {
+    code: `
+      let foo = () => 'bar';
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 5,
+        endLine: 1,
+        endColumn: 22
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = () => 'bar';
+    `,
+    options: [
+      {
+        constAllowed: ['Literal']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 24
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = () => 'bar';
+    `,
+    options: [
+      {
+        constAllowed: ['MemberExpression']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 24
       }
     ]
   }


### PR DESCRIPTION
Closes #538

## Summary

Add support for allowing (resp. disallowing) top level `const` assignments of arrow functions. Like literals and member expressions, this will be allowed by default (because arrow functions are very much like literals).