### PR TITLE
Harden CI workflow against shell/script injection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,19 +62,25 @@ jobs:
       - name: Get major version
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: major-version
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
         with:
           result-encoding: string
           script: |
-            const version = "${{ needs.check.outputs.version }}"
+            const version = `${process.env.VERSION}`
             const major = version.replace(/\.\d\.\d$/, "")
             return major
       - name: Publish git tag
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
         run: |
-          git tag '${{ needs.check.outputs.version }}'
-          git push origin '${{ needs.check.outputs.version }}'
+          git tag "$VERSION"
+          git push origin "$VERSION"
       - name: Update major version branch
+        env:
+          MAJOR_VERSION: ${{ steps.major-version.outputs.result }}
         run: |
-          git push origin 'HEAD:${{ steps.major-version.outputs.result }}'
+          git push origin "HEAD:$MAJOR_VERSION"
   npm:
     name: npm
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #298

## Summary

Update workflows based on [the blog post "Four tips to keep your GitHub Actions workflows secure"](https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure). Review was done manually.