### PR TITLE
Remove outdated `(at)author` from source code

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,6 @@ import {noTopLevelVariables} from './rules/no-top-level-variables';
 
 /**
  * @fileoverview Disallow side effects at the top level of files
- * @author Damien Erambert
  */
 
 /**


### PR DESCRIPTION
## Summary

All authors are listed in the package manifest instead.