### PR TITLE
Remove explicit `CI: true` from CI configurations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -285,7 +285,6 @@ jobs:
       - name: Run mutation tests
         run: npm run test:mutation
         env:
-          CI: true
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
   vet:
     name: Vet


### PR DESCRIPTION
## Summary

It's set by default anyways: <https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/>