### PR TITLE
Stop using Stryker dashboard

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -261,7 +261,6 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
-            dashboard.stryker-mutator.io:443
             github.com:443
             nodejs.org:443
             objects.githubusercontent.com:443
@@ -284,8 +283,6 @@ jobs:
         run: npm clean-install
       - name: Run mutation tests
         run: npm run test:mutation
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
   vet:
     name: Vet
     runs-on: ubuntu-22.04

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -19,7 +19,7 @@ module.exports = {
   checkers: ['typescript'],
   tsconfigFile: 'tsconfig.json',
 
-  reporters: ['clear-text', 'dashboard', 'html', 'progress'],
+  reporters: ['clear-text', 'html', 'progress'],
   htmlReporter: {
     fileName: '_reports/mutation/index.html'
   },


### PR DESCRIPTION
## Summary

While I quite like the mutation testing transparency provided by the Stryker dashboard, I don't particularly like the secret requirement. It introduces a largely unnecessary CI attack concern (admittedly low impact as well, but still), and crucially also doesn't work for external contributions (in which it would be most helpful, I think).

### Post-merge

- [ ] Remove the `STRYKER_DASHBOARD_TOKEN` secret