### PR TITLE
Ignore GHSA-m95q-7qp3-xv42

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,6 @@
 {
+  "GHSA-m95q-7qp3-xv42": {
+    "active": true,
+    "notes": "ReDoS in the devDependency tree without mitigation available. Mitigation should come in when available through automation."
+  }
 }


### PR DESCRIPTION
## Summary

Configure `better-npm-audit` to ignore GHSA-m95q-7qp3-xv42. See diff for motivation to ignore.