### PR TITLE
Add basic reproducible build job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -178,7 +178,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Install Node.js

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -169,6 +169,35 @@ jobs:
       - name: Lint YAML
         if: ${{ failure() || success() }}
         run: npm run lint:yml -- --debug
+  reproducible:
+    name: Reproducible build
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Install Node.js
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Build
+        run: npm run build
+      - name: Compute checksum
+        run: shasum index.js | tee checksums.txt
+      - name: Reset to a clean state
+        run: npm run clean
+      - name: Rebuild
+        run: npm run build
+      - name: Verify checksum
+        run: shasum --check checksums.txt --strict
   test:
     name: Test
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache/
 .temp/
 _reports/
+checksums.txt
 index.js
 
 # ESLint


### PR DESCRIPTION
## Summary

Create a new CI job that verifies builds are reproducible for this project. This job depends on the build  job as the build shouldn't be expected to be reproducible if it doesn't work to begin with.

Reproducible builds simplify verifying the build was done correctly for, e.g., the published package.