### PR TITLE
Add SPDX license ids to OSS documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to `@ericcornelissen/eslint-plugin-top` will be documented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The `@ericcornelissen/eslint-plugin-top` project welcomes contributions and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 If you need to release a new version of `@ericcornelissen/eslint-plugin-top`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the `@ericcornelissen/eslint-plugin-top` project take


### PR DESCRIPTION
Relates to #402

## Summary

Expand the use of SPDX license identifiers to cover the OSS (open source software) documentation files.