### PR TITLE
Configure default assignee for bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: daily
       time: '05:00'
+    assignees:
+      - ericcornelissen
     labels:
       - dependencies
     groups:
@@ -23,5 +25,7 @@ updates:
     schedule:
       interval: daily
       time: '05:00'
+    assignees:
+      - ericcornelissen
     labels:
       - dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@80dab8d99cefefdcfcc6ad4adbb6bc7a07c39e7f # v0.3.7
         with:
+          assignees: ericcornelissen
           labels: dependencies
           max: 1
           token: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -53,6 +53,7 @@ jobs:
           body: |
             _This Pull Request was created automatically_
           branch: npm-transitive-dependencies
+          assignees: ericcornelissen
           labels: dependencies
           commit-message: Update transitive dependencies
           add-paths: |


### PR DESCRIPTION
## Summary

Configure Dependabot, [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request), and [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action) to automatically set the default assignee for Pull Request they generating. This is based on historical precedence [for Dependabot](https://github.com/ericcornelissen/eslint-plugin-top/pulls?q=is%3Apr+author%3Aapp%2Fdependabot) and [for other automated PRs](https://github.com/ericcornelissen/eslint-plugin-top/pulls?q=is%3Apr+author%3Aapp%2Fec-automation-bot).

The configuration changes are based on the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees), [`peter-evans/create-pull-request` docs](https://github.com/peter-evans/create-pull-request#action-inputs), [`ericcornelissen/tool-versions-update-action` docs](https://github.com/ericcornelissen/tool-versions-update-action/tree/v0.3.7/pr#usage).