### PR TITLE
Verify reproducibility of published package

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -196,14 +196,23 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Build
-        run: npm run build
+      - name: Simulate publish
+        run: |
+          # Dry run publish to trigger any hooks
+          npm publish --dry-run
+
+          # Pack to produce the archive that would be published
+          npm pack
       - name: Compute checksum
-        run: shasum index.js | tee checksums.txt
+        run: shasum -- *.tgz | tee checksums.txt
       - name: Reset to a clean state
-        run: npm run clean
-      - name: Rebuild
-        run: npm run build
+        run: |
+          npm run clean
+          rm -- *.tgz
+      - name: Simulate publish again
+        run: |
+          npm publish --dry-run
+          npm pack
       - name: Verify checksum
         run: shasum --check checksums.txt --strict
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ index.js
 node_modules/
 .npm/
 .node_repl_history
+ericcornelissen-eslint-plugin-top-*.tgz
 npm-debug.log*


### PR DESCRIPTION
Relates to #668

## Summary

Update the continuous reproducibility check to not just verify that the build is reproducible, but that the published package bits that go to the npm registry are.