### PR TITLE
Align Dependabot labels with Labeler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,5 @@ updates:
     assignees:
       - ericcornelissen
     labels:
+      - ci
       - dependencies


### PR DESCRIPTION
## Summary

Align Dependabot labels for GitHub Actions with labeler config, specifically the [rule for `.github/workflows/*`](https://github.com/ericcornelissen/eslint-plugin-top/blob/a44e85547612d4e708014a1360630002285a9a1e/.github/labeler.yml#L6).