### PR TITLE
Don't upload coverage if job is cancelled

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -249,7 +249,7 @@ jobs:
         run: npm run coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           file: ./_reports/coverage/lcov.info
   test-compat:


### PR DESCRIPTION
Relates to #201

## Summary

Don't upload coverage if job is cancelled.