### PR TITLE
Disable lifecycle scripts by default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -292,7 +292,7 @@ jobs:
         with:
           name: index-js
       - name: Run compatibility tests
-        run: npm run test:compat --ignore-scripts
+        run: npm run test:compat
   test-mutation:
     name: Mutation tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Simulate publish
         run: |
           # Dry run publish to trigger any hooks
-          npm publish --dry-run
+          npm publish --dry-run --ignore-scripts=false
 
           # Pack to produce the archive that would be published
           npm pack
@@ -211,7 +211,7 @@ jobs:
           rm -- *.tgz
       - name: Simulate publish again
         run: |
-          npm publish --dry-run
+          npm publish --dry-run --ignore-scripts=false
           npm pack
       - name: Verify checksum
         run: shasum --check checksums.txt --strict

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,6 @@ jobs:
         run: npm clean-install
       - name: Publish to npm
         run: |
-          npm publish --provenance
+          npm publish --ignore-scripts=false --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 audit=false
+ignore-scripts=true
 lockfile-version=3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,7 @@ ESLint versions and compares the output against known snapshots. You can run
 this test suite using:
 
 ```shell
+npm run build
 npm run test:compat
 ```
 
@@ -185,6 +186,7 @@ runs the compatibility test suite on every supported Node.js version. You can
 also do this locally using:
 
 ```shell
+npm run build
 npm run test:compat-all
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ If you decide to make a contribution, please do use the following workflow:
 
 ### Development Details
 
-Before you start making changes you should run npm install. This ensures your
+Before you start making changes you should run `npm install`. This ensures your
 local development environment is setup and ready to go. All code and tests are
 written in TypeScript, documentation in Markdown, and scripts using JavaScript.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -119,6 +119,7 @@ version (using `v2.4.1` as an example):
 
    ```shell
    npm clean-install
+   npm run prepublishOnly
    npm publish
    ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -120,7 +120,7 @@ version (using `v2.4.1` as an example):
    ```shell
    npm clean-install
    npm run prepublishOnly
-   npm publish
+   npm publish --ignore-scripts=false
    ```
 
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging

--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "pretest:compat": "npm run build",
-    "pretest:compat-all": "npm run build",
-    "prevet:package.json": "npm run build",
     "_eslint": "eslint --report-unused-disable-directives",
     "_prettier": "prettier ./**/*.{js,json,jsonc,md,ts,yml} --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
@@ -86,13 +83,13 @@
     "lint:yml": "npm run _eslint -- . --ext .yml",
     "test": "mocha tests/unit --recursive",
     "test:compat": "mocha tests/compat --recursive",
-    "test:compat-all": "nve 18.0.0,20.0.0 npm run test:compat --ignore-scripts",
+    "test:compat-all": "nve 18.0.0,20.0.0 npm run test:compat",
     "test:mutation": "stryker run stryker.config.js",
     "test:watch": "npm run test -- --watch",
     "verify": "npm run build && npm run format:check && npm run lint && npm run test && npm run vet",
     "vet": "npm run vet:imports && npm run vet:package.json && npm run vet:types",
     "vet:imports": "knip --config knip.jsonc",
-    "vet:package.json": "publint run --strict",
+    "vet:package.json": "npm run build && publint run --strict",
     "vet:types": "type-coverage --at-least 100 --cache --cache-directory .cache --project tsconfig.json --strict"
   }
 }


### PR DESCRIPTION
## Summary

Update the repository configuration to disable lifecycle scripts (such as installation scripts) by default. None of this project's current dependencies require such scripts, so from that perspective it's fine. Perhaps the most challenging thing is that the `prepublishOnly` script no longer runs when publishing. To mitigate this all invocations of `npm publish` in the project explicitly override `--ignore-scripts` to enable lifecycle hooks, and the release guidelines also recommend explicitly running it to reduce the risk of user error.

The motivation for this is to improve the project's security because it is quite common for supply chain attacks to utilize lifecycle scripts. The drawback is that some lifecycle scripts are used (as seen above) or that some dependencies might require them. When a dependency is introduced (newly or through an update) that requires it a mitigation will be evaluated.