### PR TITLE
Check for top-level-variables in `export` declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`bed2d39`) Report named export declarations for `no-top-level-variables`.
 
 ## [2.1.0] - 2023-08-06
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -1,9 +1,20 @@
 // SPDX-License-Identifier: ISC
 
 import type {Rule} from 'eslint';
-import type {Expression, CallExpression, VariableDeclarator} from 'estree';
+import type {
+  Declaration,
+  Expression,
+  CallExpression,
+  VariableDeclaration,
+  VariableDeclarator
+} from 'estree';
 
 import {isTopLevel} from '../helpers';
+
+type Options = {
+  readonly constAllowed: ReadonlyArray<string>;
+  readonly kind: ReadonlyArray<string>;
+};
 
 const violationMessage = 'Variables at the top level are not allowed';
 
@@ -16,6 +27,57 @@ const kindValues = ['const', 'let', 'var'];
 
 function isRequireCall(node: CallExpression): boolean {
   return node.callee.type === 'Identifier' && node.callee.name === 'require';
+}
+
+function checker(
+  context: Rule.RuleContext,
+  options: Options,
+  node: VariableDeclaration
+) {
+  if (!Array.from(options.kind).includes(node.kind)) {
+    return;
+  }
+
+  let allowedDeclaration: (declaration: VariableDeclarator) => boolean;
+  if (node.kind === 'const') {
+    const isArrowFunctionAllowed = options.constAllowed.includes(
+      'ArrowFunctionExpression'
+    );
+    const isLiteralAllowed = options.constAllowed.includes('Literal');
+    const isMemberExpressionAllowed =
+      options.constAllowed.includes('MemberExpression');
+
+    allowedDeclaration = (declaration) => {
+      // type-coverage:ignore-next-line
+      switch ((declaration.init as Expression).type) {
+        case 'ArrowFunctionExpression':
+          return isArrowFunctionAllowed;
+        case 'CallExpression': {
+          // type-coverage:ignore-next-line
+          return isRequireCall(declaration.init as CallExpression);
+        }
+        case 'Literal':
+          return isLiteralAllowed;
+        case 'MemberExpression':
+          return isMemberExpressionAllowed;
+        default:
+          return false;
+      }
+    };
+  } else {
+    allowedDeclaration = (declaration) =>
+      declaration.init?.type === 'CallExpression' &&
+      isRequireCall(declaration.init);
+  }
+
+  node.declarations
+    .filter((declaration) => !allowedDeclaration(declaration))
+    .forEach((declaration) => {
+      context.report({
+        node: declaration,
+        messageId: 'message'
+      });
+    });
 }
 
 export const noTopLevelVariables: Rule.RuleModule = {
@@ -47,10 +109,7 @@ export const noTopLevelVariables: Rule.RuleModule = {
     ]
   },
   create: (context) => {
-    const options: {
-      readonly constAllowed: ReadonlyArray<string>;
-      readonly kind: ReadonlyArray<string>;
-    } = {
+    const options: Options = {
       // type-coverage:ignore-next-line
       constAllowed: context.options[0]?.constAllowed || constAllowedValues,
       // type-coverage:ignore-next-line
@@ -58,54 +117,17 @@ export const noTopLevelVariables: Rule.RuleModule = {
     };
 
     return {
+      ExportNamedDeclaration: (node) => {
+        // type-coverage:ignore-next-line
+        const declaration = node.declaration as Declaration;
+        if (declaration.type === 'VariableDeclaration') {
+          checker(context, options, declaration);
+        }
+      },
       VariableDeclaration: (node) => {
-        if (
-          !isTopLevel(node) ||
-          !Array.from(options.kind).includes(node.kind)
-        ) {
-          return;
+        if (isTopLevel(node)) {
+          checker(context, options, node);
         }
-
-        let allowedDeclaration: (declaration: VariableDeclarator) => boolean;
-        if (node.kind === 'const') {
-          const isArrowFunctionAllowed = options.constAllowed.includes(
-            'ArrowFunctionExpression'
-          );
-          const isLiteralAllowed = options.constAllowed.includes('Literal');
-          const isMemberExpressionAllowed =
-            options.constAllowed.includes('MemberExpression');
-
-          allowedDeclaration = (declaration) => {
-            // type-coverage:ignore-next-line
-            switch ((declaration.init as Expression).type) {
-              case 'ArrowFunctionExpression':
-                return isArrowFunctionAllowed;
-              case 'CallExpression': {
-                // type-coverage:ignore-next-line
-                return isRequireCall(declaration.init as CallExpression);
-              }
-              case 'Literal':
-                return isLiteralAllowed;
-              case 'MemberExpression':
-                return isMemberExpressionAllowed;
-              default:
-                return false;
-            }
-          };
-        } else {
-          allowedDeclaration = (declaration) =>
-            declaration.init?.type === 'CallExpression' &&
-            isRequireCall(declaration.init);
-        }
-
-        node.declarations
-          .filter((declaration) => !allowedDeclaration(declaration))
-          .forEach((declaration) => {
-            context.report({
-              node: declaration,
-              messageId: 'message'
-            });
-          });
       }
     };
   }

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -93,6 +93,28 @@ const valid: RuleTester.ValidTestCase[] = [
         constAllowed: ['ArrowFunctionExpression']
       }
     ]
+  },
+  {
+    code: `
+      export const bar = 1337;
+    `
+  },
+  {
+    code: `
+      var bar = 1337;
+    `,
+    options: [
+      {
+        kind: ['let', 'const']
+      }
+    ]
+  },
+  {
+    code: `
+      export class ClassName { }
+      export function functionName() { }
+      export function* generatorName() { }
+    `
   }
 ];
 
@@ -513,6 +535,53 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 24
+      }
+    ]
+  },
+  {
+    code: `
+      export var foo = "bar";
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 12,
+        endLine: 1,
+        endColumn: 23
+      }
+    ]
+  },
+  {
+    code: `
+      export let bar = 1337;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 12,
+        endLine: 1,
+        endColumn: 22
+      }
+    ]
+  },
+  {
+    code: `
+      export const foo = () => "bar";
+    `,
+    options: [
+      {
+        constAllowed: ['Literal']
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 14,
+        endLine: 1,
+        endColumn: 31
       }
     ]
   }


### PR DESCRIPTION
## Summary

Export declarations may declare variables at the top level. Previously, these would go undetected by this linter. Now, it considers those just like it does top-level variable declarations.

None of the other `export` syntax is relevant to this rule, as those don't allow for declarations, per <https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export>.