### PR TITLE
Allow top-level const assignments from identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`ba81b6d`) Allow top-level `const` assignment from literals.
 - (`bed2d39`) Report named export declarations for `no-top-level-variables`.
 
 ## [2.1.0] - 2023-08-06

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -56,6 +56,8 @@ function checker(
           // type-coverage:ignore-next-line
           return isRequireCall(declaration.init as CallExpression);
         }
+        case 'Identifier':
+          return true;
         case 'Literal':
           return isLiteralAllowed;
         case 'MemberExpression':

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -126,6 +126,7 @@ const valid: RuleTester.ValidTestCase[] = [
   {
     code: `
       const { name1, name2: name3 } = o;
+      const [ name4, name5 ] = a;
     `
   },
   {

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -96,11 +96,6 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
-      export const bar = 1337;
-    `
-  },
-  {
-    code: `
       var bar = 1337;
     `,
     options: [
@@ -111,10 +106,37 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
+      export const bar = 1337;
+    `
+  },
+  {
+    code: `
+      const foo = bar;
+    `
+  },
+  {
+    code: `
       export class ClassName { }
       export function functionName() { }
       export function* generatorName() { }
+      export const { name1, name2: name3 } = o;
+      export const [ name4, name5 ] = a;
     `
+  },
+  {
+    code: `
+      const { name1, name2: name3 } = o;
+    `
+  },
+  {
+    code: `
+      const { bar } = foo;
+    `,
+    options: [
+      {
+        constAllowed: []
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #736

## Summary

Expand top-level-variable assignments allowed for `const` to include assignment from an identifier. This covers variable-to-const assignments as well as destructuring assignments.