### PR TITLE
Report side effects as part of export statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 
 - (`ba81b6d`) Allow top-level `const` assignment from literals.
 - (`bed2d39`) Report named export declarations for `no-top-level-variables`.
+- (`efd1232`) Report side effects in exports for `no-top-level-side-effects`.
 
 ## [2.1.0] - 2023-08-06
 

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -66,6 +66,11 @@ const valid: RuleTester.ValidTestCase[] = [
         }
       }
     `
+  },
+  {
+    code: `
+      export const hello = 'world';
+    `,
   }
 ];
 
@@ -325,6 +330,34 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 1,
         endLine: 1,
         endColumn: 28
+      }
+    ]
+  },
+  {
+    code: `
+      module.exports = console.log('hello world');
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 18,
+        endLine: 1,
+        endColumn: 44
+      }
+    ]
+  },
+  {
+    code: `
+      export const hello = console.log('hello world');
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 22,
+        endLine: 1,
+        endColumn: 48
       }
     ]
   }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -70,7 +70,7 @@ const valid: RuleTester.ValidTestCase[] = [
   {
     code: `
       export const hello = 'world';
-    `,
+    `
   }
 ];
 


### PR DESCRIPTION
Relates to #736

## Summary

Update the `no-top-level-side-effects` rule to report on the presence of side effects in export statements (both CJS and ESM).