### PR TITLE
Report side effects as part of top-level variable declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning].
 - (`ba81b6d`) Allow top-level `const` assignment from literals.
 - (`bed2d39`) Report named export declarations for `no-top-level-variables`.
 - (`efd1232`) Report side effects in exports for `no-top-level-side-effects`.
+- (`cd61a0a`) Report side effects in variable declarations for
+  `no-top-level-side-effects`.
 
 ## [2.1.0] - 2023-08-06
 

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -360,6 +360,36 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 48
       }
     ]
+  },
+  {
+    code: `
+      var foo1 = console.log('bar1');
+      let foo2 = console.log('bar2');
+      const foo3 = console.log('bar3');
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 12,
+        endLine: 1,
+        endColumn: 31
+      },
+      {
+        messageId: 'message',
+        line: 2,
+        column: 18,
+        endLine: 2,
+        endColumn: 37
+      },
+      {
+        messageId: 'message',
+        line: 3,
+        column: 20,
+        endLine: 3,
+        endColumn: 39
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #739

## Summary

Update the `no-top-level-side-effects` rule to report on the presence of side effects in variable declarations at the top level.