### PR TITLE
Optionally allow creating `Symbol` as top-level side effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 ## [Unreleased]
 
 - (`ba81b6d`) Allow top-level `const` assignment from literals.
+- (`bc90491`) Optionally allow `Symbol()` for `no-top-level-side-effects`.
 - (`bed2d39`) Report named export declarations for `no-top-level-variables`.
 - (`efd1232`) Report function calls in exports for `no-top-level-side-effects`.
 - (`cd61a0a`) Report function calls in variable declarations for

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -69,10 +69,12 @@ This rule accepts a configuration object with one option:
 
 - `allowIIFE: false` (default) Configure whether top level Immediately Invoked
   Function Expressions are allowed.
+- `allowSymbol: true` (default) Configure whether top level assignments can call
+  `Symbol()`.
 
 #### allowIIFE
 
-Examples of **correct** code when set to `true`:
+Examples of **correct** code when `'allowIIFE'` is set to `true`:
 
 ```javascript
 (function () {
@@ -98,6 +100,14 @@ Examples of **correct** code when set to `true`:
 
   fetch('/api').then((res) => res.text());
 })();
+```
+
+Examples of **correct** code when `'allowSymbol'` is set to `true`:
+
+```javascript
+var s1 = Symbol();
+let s2 = Symbol();
+const s3 = Symbol();
 ```
 
 ## When Not To Use It

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -71,6 +71,23 @@ const valid: RuleTester.ValidTestCase[] = [
     code: `
       export const hello = 'world';
     `
+  },
+  {
+    code: `
+      const s1 = Symbol();
+      export const s2 = Symbol();
+    `
+  },
+  {
+    code: `
+      const s1 = Symbol();
+      export const s2 = Symbol();
+    `,
+    options: [
+      {
+        allowSymbol: true
+      }
+    ]
   }
 ];
 
@@ -514,6 +531,60 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 20,
         endLine: 5,
         endColumn: 29
+      }
+    ]
+  },
+  {
+    code: `
+      const f1 = f();
+      export const f2 = f();
+    `,
+    options: [
+      {
+        allowSymbol: true
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 12,
+        endLine: 1,
+        endColumn: 15
+      },
+      {
+        messageId: 'message',
+        line: 2,
+        column: 25,
+        endLine: 2,
+        endColumn: 28
+      }
+    ]
+  },
+  {
+    code: `
+      const s1 = Symbol();
+      export const s2 = Symbol();
+    `,
+    options: [
+      {
+        allowSymbol: false
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 12,
+        endLine: 1,
+        endColumn: 20
+      },
+      {
+        messageId: 'message',
+        line: 2,
+        column: 25,
+        endLine: 2,
+        endColumn: 33
       }
     ]
   }


### PR DESCRIPTION
Closes #568
Relates to #739, #740

## Summary

Adjust the reporting for `no-top-level-side-effects` to optionally allow calling `Symbol()` at the top level. Initializing symbols at the top level is the only way to create symbols at the top-level, and can be viewed as similar to initializing to a literal. This is allowed by default, but can be disabled.