### PR TITLE
Optionally allow top-level `const` objects and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`8e4566b`) Optionally allow top-level `const` assignments of arrays and
+  objects.
 
 ## [2.2.0] - 2023-12-24
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -54,6 +54,12 @@ This rule accepts a configuration object with two options:
 
 #### constAllowed
 
+Examples of **correct** code when `'ArrayExpression'` is allowed:
+
+```javascript
+const arr = [1, 2, 3];
+```
+
 Examples of **correct** code when `'ArrowFunctionExpression'` is allowed:
 
 ```javascript
@@ -74,6 +80,12 @@ Examples of **correct** code when `'MemberExpression'` is allowed:
 ```javascript
 const parse = JSON.parse;
 const map = Array.prototype.map;
+```
+
+Examples of **correct** code when `'ObjectExpression'` is allowed:
+
+```javascript
+const obj = {foo: 'bar'};
 ```
 
 #### kind

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -138,6 +138,26 @@ const valid: RuleTester.ValidTestCase[] = [
         constAllowed: []
       }
     ]
+  },
+  {
+    code: `
+      const foo = { bar: "baz" };
+    `,
+    options: [
+      {
+        constAllowed: ['ObjectExpression']
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = ["b", "a", "r"];
+    `,
+    options: [
+      {
+        constAllowed: ['ArrayExpression']
+      }
+    ]
   }
 ];
 
@@ -647,6 +667,34 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 19,
         endLine: 1,
         endColumn: 24
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = { bar: "baz" };
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 27
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = ["b", "a", "r"];
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 28
       }
     ]
   }


### PR DESCRIPTION
## Summary

Adjust the reporting for `no-top-level-variables` to optionally allow assigning objects and arrays to top level `const`s. This is not allowed by default because these are mutable values.