### PR TITLE
Top-level `require` call should not be considered a side effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`fced786`) Allow `require()` for `no-top-level-side-effects`.
 - (`8e4566b`) Optionally allow top-level `const` assignments of arrays and
   objects.
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -71,8 +71,8 @@ function sideEffectInExpression(
     if (
       !(
         expression.callee.type === 'Identifier' &&
-        expression.callee.name === 'Symbol' &&
-        options.allowSymbol
+        ((expression.callee.name === 'Symbol' && options.allowSymbol) ||
+          expression.callee.name === 'require')
       )
     ) {
       context.report({

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -88,6 +88,13 @@ const valid: RuleTester.ValidTestCase[] = [
         allowSymbol: true
       }
     ]
+  },
+  {
+    code: `
+      var fs = require('fs');
+      let cp = require('child_process');
+      const path = require('path');
+    `
   }
 ];
 


### PR DESCRIPTION
Relates to #740

## Summary

The changes of [v2.2.0](https://github.com/ericcornelissen/eslint-plugin-top/releases/tag/v2.2.0) made it so more top-level-side-effects would be reported, notably as part of variable assignments. As a side effect, top-level use of `require()` is now reported. Similar to the top-level-variables rule this shouldn't be the case since there's no other way to import things in CJS code.