### PR TITLE
Top-level const `Symbol` should not be considered a variable problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 ## [Unreleased]
 
 - (`fced786`) Allow `require()` for `no-top-level-side-effects`.
+- (`c46dec9`) Allow `Symbol()` for `const` in `no-top-level-variables`.
 - (`8e4566b`) Optionally allow top-level `const` assignments of arrays and
   objects.
 

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -158,6 +158,11 @@ const valid: RuleTester.ValidTestCase[] = [
         constAllowed: ['ArrayExpression']
       }
     ]
+  },
+  {
+    code: `
+      const s = Symbol();
+    `
   }
 ];
 


### PR DESCRIPTION
Relates to #740, #747

## Summary

The changes of [v2.2.0](https://github.com/ericcornelissen/eslint-plugin-top/releases/tag/v2.2.0) made it so using `Symbol` isn't necessarily considered a top-level side effect problem. However, the `no-top-level-variables` rule still considers it a problem, which is a bit odd.