### PR TITLE
Rework the `no-top-level-variables` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`207ad89`) _(Breaking)_ Rework the `no-top-level-variables` rule to focus on
+  variables being mutable instead of other side effects.
 
 ## [2.2.2] - 2023-12-24
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -1,134 +1,115 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # No top level variables (no-top-level-variables)
 
 Disallow top level variables.
 
-Variables at the top level may indicate side effects. It may be initialized by
-means of a function call, which is a side effect. Or it may be used as state in
-the functions or methods of the module, which means it's used for side effects.
-
-As such, `const` is handled differently from `let` and `var` since it's value is
-not meant to be mutated.
+Variables at the top level may indicate side effects because it may be used as
+state in functions or methods. As such, `const` is the only kind of top-level
+variable allowed by default, and it can only be assigned certain values.
 
 ## Rule Details
 
-This rule lets you control top level variable assignments.
+This rule lets you control top level variables.
 
 Examples of **incorrect** code for this rule:
 
 ```javascript
 var answer = 42;
 let foo = 'bar';
-const list = new Array();
+const arr = [];
 ```
 
 Examples of **correct** code for this rule:
 
 ```javascript
-var fs = require('node:fs');
-let path = require('node:path');
-const util = require('node:util');
-```
-
-```javascript
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as util from 'node:util';
 
 const leet = 1337;
+const l33t = leet;
+
+function f() {
+  var answer = 42;
+}
+
+const g = () => {
+  let foo = 'bar';
+};
+
+const h = function () {
+  const arr = [];
+};
 
 export default function () {
-  var answer = 42;
-  let foo = 'bar';
-  const list = new Array();
+  // ...
 }
+
+export const foo = 'bar';
+```
+
+```javascript
+const util = require('node:util');
+
+module.exports = {
+  foo: 'bar'
+};
 ```
 
 ### Options
 
 This rule accepts a configuration object with two options:
 
-- `constAllowed`: Configure what assignments are allowed for `const`. By default
-  functions, literals, and member expression assignments are allowed.
-- `kind`: Configure which kinds of variables are forbidden. By default all of
-  `const`, `let`, and `var` are forbidden.
+- `allowed`: Configure what kind of assignments are allowed. Some assignments
+  are always allowed and some assignments are never allowed. The configurable
+  assignments are described below.
+- `kind`: Configure which kinds of variables are allowed. By default only
+  `const` variables are allowed.
 
-#### constAllowed
+#### `allowed`
 
-Examples of **correct** code when `'ArrayExpression'` is allowed:
+Examples of **correct** code when `'ArrayExpression'` is in the list:
 
 ```javascript
 const arr = [1, 2, 3];
 ```
 
-Examples of **correct** code when `'ArrowFunctionExpression'` is allowed:
+Examples of **correct** code when `'ObjectExpression'` is in the list:
 
 ```javascript
-const answer = () => 42;
-const hello = (name) => `Hello ${name}!`;
+const hello = {world: '!'};
 ```
 
-Examples of **correct** code when `'FunctionExpression'` is allowed:
+#### `kind`
 
-```javascript
-const answer = function () {
-  return 42;
-};
-const hello = function (name) {
-  return `Hello ${name}!`;
-};
-```
+This option allows you to allow the use of any combination of `const`, `let`,
+and `var` at the top-level in your code base. Unless there is a historical or
+compatibility reason to allow `var` or `let`, it is recommended to only allow
+`const`.
 
-Examples of **correct** code when `'Literal'` is allowed:
+By setting this to an empty list you can disallow all top-level variables.
 
-```javascript
-const answer = 42;
-const hello = 'world!';
-const NULL = null;
-```
-
-Examples of **correct** code when `'MemberExpression'` is allowed:
-
-```javascript
-const parse = JSON.parse;
-const map = Array.prototype.map;
-```
-
-Examples of **correct** code when `'ObjectExpression'` is allowed:
-
-```javascript
-const obj = {foo: 'bar'};
-```
-
-Examples of **correct** code when `'TemplateLiteral'` is allowed:
-
-```javascript
-const foo = `bar`;
-```
-
-#### kind
-
-Examples of **correct** code when `'const'` is not in the list:
-
-```javascript
-const answer = 42;
-const list = new Array();
-const foobar = JSON.parse('{"foo":"bar"}');
-```
-
-Examples of **correct** code when `'let'` is not in the list:
-
-```javascript
-let answer = 42;
-let list = new Array();
-let foobar = JSON.parse('{"foo":"bar"}');
-```
-
-Examples of **correct** code when `'var'` is not in the list:
+Examples of **correct** code when `'const'` is in the list:
 
 ```javascript
 var answer = 42;
-var list = new Array();
-var foobar = JSON.parse('{"foo":"bar"}');
+let foo = 'bar';
+const path = require('path');
+```
+
+Examples of **correct** code when `'let'` is in the list:
+
+```javascript
+var answer = 42;
+let foo = 'bar';
+const path = require('path');
+```
+
+Examples of **correct** code when `'var'` is in the list:
+
+```javascript
+var answer = 42;
+let foo = 'bar';
+const path = require('path');
 ```
 
 ## When Not To Use It

--- a/tests/compat/helpers.ts
+++ b/tests/compat/helpers.ts
@@ -22,6 +22,9 @@ export function runEslint(version: number, snippet: string): {stdout: string} {
       '--no-eslintrc',
       // Lint from stdin
       '--stdin',
+      // Allow modern (ES6) syntax
+      '--env',
+      'es6',
       // Configure this plugin
       '--plugin',
       '@ericcornelissen/top',

--- a/tests/compat/snapshots.ts
+++ b/tests/compat/snapshots.ts
@@ -8,13 +8,14 @@ interface Snapshot {
 
 export const snapshots: ReadonlyArray<Snapshot> = [
   {
-    name: 'with top-level-variables violation',
-    inp: 'var foo = "bar";',
+    name: 'with no-top-level-variables violations',
+    inp: 'const foo = ["bar"];var hello = ["world", "!"];',
     out: `
 <text>
-  1:5  error  Variables at the top level are not allowed  @ericcornelissen/top/no-top-level-variables
+  1:7   error  Variables at the top level are not allowed  @ericcornelissen/top/no-top-level-variables
+  1:21  error  Use of var at the top level is not allowed  @ericcornelissen/top/no-top-level-variables
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 2 problems (2 errors, 0 warnings)
 
 `
   },

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -9,34 +9,22 @@ import {noTopLevelVariables} from '../../lib/rules/no-top-level-variables';
 const valid: RuleTester.ValidTestCase[] = [
   {
     code: `
-      export default function () {
+      function fVar() {
         var foo = 'bar';
       }
-    `
-  },
-  {
-    code: `
-      export default function () {
+      function fLet() {
         let foo = 'bar';
       }
-    `
-  },
-  {
-    code: `
-      export default function () {
+      function fConst() {
         const foo = 'bar';
       }
     `
   },
   {
     code: `
-      const path = require('path');
-    `
-  },
-  {
-    code: `
-      const foo = 'bar';
-      export default function () {}
+      var path = require('path');
+      var foo1 = 'bar';
+      export var foo2 = 'bar';
     `,
     options: [
       {
@@ -46,72 +34,42 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
-      const bar = 1337;
-    `
-  },
-  {
-    code: `
-      const path = require('path'), foo = 'bar';
-    `
-  },
-  {
-    code: `
-      const isArray = Array.isArray;
-    `
-  },
-  {
-    code: `
-      const pi = 3.14;
+      let path = require('path');
+      let foo1 = 'bar';
+      export let foo2 = 'bar';
     `,
     options: [
       {
-        constAllowed: ['Literal']
+        kind: ['let']
       }
     ]
   },
   {
     code: `
-      const isArray = Array.isArray;
-    `,
-    options: [
-      {
-        constAllowed: ['MemberExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = () => 'bar';
+      class ClassName { }
+      function functionName() { }
+      function* generatorName() { }
     `
   },
   {
     code: `
-      const foo = () => 'bar';
-    `,
-    options: [
-      {
-        constAllowed: ['ArrowFunctionExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      var bar = 1337;
-    `,
-    options: [
-      {
-        kind: ['let', 'const']
-      }
-    ]
-  },
-  {
-    code: `
-      export const bar = 1337;
-    `
-  },
-  {
-    code: `
+      const leet = 1337;
+
+      const foo1 = 'bar';
+      const foo2 = "bar";
+      const foo3 = \`bar\`;
+
       const foo = bar;
+      const isArray = Array.isArray;
+
+      const f = function() { };
+      const g = () => 'bar';
+
+      const { name1, name2: name3 } = o;
+      const [ name4, name5 ] = a;
+
+      const s = Symbol();
+      const path = require('path');
     `
   },
   {
@@ -119,23 +77,35 @@ const valid: RuleTester.ValidTestCase[] = [
       export class ClassName { }
       export function functionName() { }
       export function* generatorName() { }
+    `
+  },
+  {
+    code: `
+      export const leet = 1337;
+
+      export const foo1 = 'bar';
+      export const foo2 = "bar";
+      export const foo3 = \`bar\`;
+
+      export const foo = bar;
+      export const isArray = Array.isArray;
+
+      export const f = function() { };
+      export const g = () => 'bar';
+
       export const { name1, name2: name3 } = o;
       export const [ name4, name5 ] = a;
+
+      export const s = Symbol();
     `
   },
   {
     code: `
-      const { name1, name2: name3 } = o;
-      const [ name4, name5 ] = a;
-    `
-  },
-  {
-    code: `
-      const { bar } = foo;
+      const foo = ["b", "a", "r"];
     `,
     options: [
       {
-        constAllowed: []
+        allowed: ['ArrayExpression']
       }
     ]
   },
@@ -145,56 +115,7 @@ const valid: RuleTester.ValidTestCase[] = [
     `,
     options: [
       {
-        constAllowed: ['ObjectExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = ["b", "a", "r"];
-    `,
-    options: [
-      {
-        constAllowed: ['ArrayExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      const s = Symbol();
-    `
-  },
-  {
-    code: `
-      const foo = function() {
-        return 'bar';
-      }
-    `
-  },
-  {
-    code: `
-      const foo = function() {
-        return 'bar';
-      }
-    `,
-    options: [
-      {
-        constAllowed: ['FunctionExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = \`bar\`;
-    `
-  },
-  {
-    code: `
-      const foo = \`bar\`;
-    `,
-    options: [
-      {
-        constAllowed: ['TemplateLiteral']
+        allowed: ['ObjectExpression']
       }
     ]
   }
@@ -203,520 +124,274 @@ const valid: RuleTester.ValidTestCase[] = [
 const invalid: RuleTester.InvalidTestCase[] = [
   {
     code: `
-      var foo = 'bar';
-      export default function () {}
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      let foo = 'bar';
-      export default function () {}
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      var foobar = 'bar';
-      const foo = 'bar';
-      export default function () {}
+      var foo1 = 'bar';
+      let foo2 = 'bar';
+      const foo3 = 'bar';
     `,
     options: [
       {
-        kind: ['var']
+        kind: []
       }
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '1',
         line: 1,
-        column: 5,
+        column: 1,
         endLine: 1,
-        endColumn: 19
-      }
-    ]
-  },
-  {
-    code: `
-      var foo;
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 8
-      }
-    ]
-  },
-  {
-    code: `
-      var foo = 'bar', hello = 'world';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 16
+        endColumn: 18
       },
       {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
-        endColumn: 33
-      }
-    ]
-  },
-  {
-    code: `
-      let foo = 'bar', hello = 'world';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 16
-      },
-      {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
-        endColumn: 33
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = 'bar', hello = world();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 20,
-        endLine: 1,
-        endColumn: 35
-      }
-    ]
-  },
-  {
-    code: `
-      var path = require('path'), foo = 'bar';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 29,
-        endLine: 1,
-        endColumn: 40
-      }
-    ]
-  },
-  {
-    code: `
-      let path = require('path'), foo = 'bar';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 29,
-        endLine: 1,
-        endColumn: 40
-      }
-    ]
-  },
-  {
-    code: `
-      const path = require('path'), foo = bar();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 31,
-        endLine: 1,
-        endColumn: 42
-      }
-    ]
-  },
-  {
-    code: `
-      var isArray = Array.isArray;
-    `,
-    options: [],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 28
-      }
-    ]
-  },
-  {
-    code: `
-      let isArray = Array.isArray;
-    `,
-    options: [],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 28
-      }
-    ]
-  },
-  {
-    code: `
-      const isArray = Array.isArray;
-    `,
-    options: [
-      {
-        constAllowed: []
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 30
-      }
-    ]
-  },
-  {
-    code: `
-      {
-        let foo = 'bar';
-      }
-    `,
-    options: [],
-    errors: [
-      {
-        messageId: 'message',
+        messageId: '2',
         line: 2,
-        column: 13,
+        column: 7,
         endLine: 2,
         endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = new Bar();
-    `,
-    options: [],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      const isArray = Array.isArray;
-    `,
-    options: [
-      {
-        constAllowed: ['ArrowFunctionExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 30
-      }
-    ]
-  },
-  {
-    code: `
-      const isArray = Array.isArray;
-    `,
-    options: [
-      {
-        constAllowed: ['Literal']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 30
-      }
-    ]
-  },
-  {
-    code: `
-      var foo = bar();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      var foo = () => 'bar';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      let foo = () => 'bar';
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 5,
-        endLine: 1,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = () => 'bar';
-    `,
-    options: [
-      {
-        constAllowed: ['Literal']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = () => 'bar';
-    `,
-    options: [
-      {
-        constAllowed: ['MemberExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      export var foo = "bar";
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 12,
-        endLine: 1,
-        endColumn: 23
-      }
-    ]
-  },
-  {
-    code: `
-      export let bar = 1337;
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 12,
-        endLine: 1,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      export const foo = () => "bar";
-    `,
-    options: [
-      {
-        constAllowed: ['Literal']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 14,
-        endLine: 1,
-        endColumn: 31
-      }
-    ]
-  },
-  {
-    code: `
-      export var name1, name2;
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 12,
-        endLine: 1,
-        endColumn: 17
       },
       {
-        messageId: 'message',
-        line: 1,
-        column: 19,
-        endLine: 1,
-        endColumn: 24
+        messageId: '3',
+        line: 3,
+        column: 7,
+        endLine: 3,
+        endColumn: 26
       }
     ]
   },
   {
     code: `
-      export let name1, name2;
+      {var foo1 = 'bar';}
+      {let foo2 = 'bar';}
+      {const foo3 = 'bar';}
     `,
+    options: [
+      {
+        kind: []
+      }
+    ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '1',
         line: 1,
-        column: 12,
+        column: 2,
         endLine: 1,
-        endColumn: 17
+        endColumn: 19
       },
       {
-        messageId: 'message',
-        line: 1,
-        column: 19,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = { bar: "baz" };
-    `,
-    errors: [
+        messageId: '2',
+        line: 2,
+        column: 8,
+        endLine: 2,
+        endColumn: 25
+      },
       {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
+        messageId: '3',
+        line: 3,
+        column: 8,
+        endLine: 3,
         endColumn: 27
       }
     ]
   },
   {
     code: `
-      const foo = ["b", "a", "r"];
+      export var foo1 = 'bar';
+      export let foo2 = 'bar';
+      export const foo3 = 'bar';
     `,
+    options: [
+      {
+        kind: []
+      }
+    ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '1',
         line: 1,
-        column: 7,
+        column: 8,
         endLine: 1,
-        endColumn: 28
+        endColumn: 25
+      },
+      {
+        messageId: '2',
+        line: 2,
+        column: 14,
+        endLine: 2,
+        endColumn: 31
+      },
+      {
+        messageId: '3',
+        line: 3,
+        column: 14,
+        endLine: 3,
+        endColumn: 33
       }
     ]
   },
   {
     code: `
-      const foo = function() {
-        return 'bar';
+      export var name1, name2;
+      export let name3, name4;
+    `,
+    errors: [
+      {
+        messageId: '1',
+        line: 1,
+        column: 8,
+        endLine: 1,
+        endColumn: 25
+      },
+      {
+        messageId: '2',
+        line: 2,
+        column: 14,
+        endLine: 2,
+        endColumn: 31
       }
+    ]
+  },
+  {
+    code: `
+      var foo1 = 'bar', hello1 = 'world';
+      let foo2 = 'bar', hello2 = 'world';
+      const foo3 = 'bar', hello3 = 'world';
     `,
     options: [
       {
-        constAllowed: []
+        kind: []
       }
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '1',
         line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 36
+      },
+      {
+        messageId: '2',
+        line: 2,
+        column: 7,
+        endLine: 2,
+        endColumn: 42
+      },
+      {
+        messageId: '3',
+        line: 3,
         column: 7,
         endLine: 3,
-        endColumn: 8
+        endColumn: 44
       }
     ]
   },
   {
     code: `
-      const foo = \`bar\`;
+      const foo = {bar: "baz"};
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 25
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = {bar: "baz"}, hello = {world: "!"};
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 1,
+        column: 27,
+        endLine: 1,
+        endColumn: 47
+      }
+    ]
+  },
+  {
+    code: `
+      const path = require('path'), foo1 = {};
+      const foo2 = {}, fs = require('fs');
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 31,
+        endLine: 1,
+        endColumn: 40
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 13,
+        endLine: 2,
+        endColumn: 22
+      }
+    ]
+  },
+  {
+    code: `
+      const arr = [];
+      const foo = ["b", "a", "r"];
     `,
     options: [
       {
-        constAllowed: []
+        allowed: ['ObjectExpression']
       }
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 7,
         endLine: 1,
-        endColumn: 18
+        endColumn: 15
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 13,
+        endLine: 2,
+        endColumn: 34
+      }
+    ]
+  },
+  {
+    code: `
+      const obj = {};
+      const foo = { bar: "baz" };
+    `,
+    options: [
+      {
+        allowed: ['ArrayExpression']
+      }
+    ],
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 15
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 13,
+        endLine: 2,
+        endColumn: 33
       }
     ]
   }


### PR DESCRIPTION
## Summary

Re-implement the `no-top-level-variables` rule to focus it on variables. In particular, this aims to remove checking for side-effects (e.g. function calls) from the rule and instead focus on the presence of mutable top-level variables.
