### PR TITLE
Always allow top-level variable assignments of literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`ebf23c6`) Always allow assignment of literals for `no-top-level-variables`.
 
 ## [2.2.1] - 2023-12-24
 

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -26,11 +26,8 @@ const constAllowedValues = [
 ];
 const kindValues = ['const', 'let', 'var'];
 
-const defaultConstAllowed = [
-  'ArrowFunctionExpression',
-  'Literal',
-  'MemberExpression'
-];
+const defaultConstAllowed = ['ArrowFunctionExpression', 'MemberExpression'];
+const alwaysConstAllowed = ['Literal'];
 
 function isRequireCall(expression: Expression | null | undefined): boolean {
   return (
@@ -119,8 +116,11 @@ export const noTopLevelVariables: Rule.RuleModule = {
   },
   create: (context) => {
     const options: Options = {
-      // type-coverage:ignore-next-line
-      constAllowed: context.options[0]?.constAllowed || defaultConstAllowed,
+      constAllowed: [
+        ...alwaysConstAllowed,
+        // type-coverage:ignore-next-line
+        ...(context.options[0]?.constAllowed || defaultConstAllowed)
+      ],
       // type-coverage:ignore-next-line
       kind: context.options[0]?.kind || kindValues
     };

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -332,25 +332,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
   },
   {
     code: `
-      const foo = 'bar';
-    `,
-    options: [
-      {
-        constAllowed: []
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 18
-      }
-    ]
-  },
-  {
-    code: `
       var isArray = Array.isArray;
     `,
     options: [],
@@ -465,44 +446,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 30
-      }
-    ]
-  },
-  {
-    code: `
-      const pi = 3.14;
-    `,
-    options: [
-      {
-        constAllowed: ['ArrowFunctionExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      const pi = 3.14;
-    `,
-    options: [
-      {
-        constAllowed: ['MemberExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 16
       }
     ]
   },


### PR DESCRIPTION
## Summary

Avoid users having to specify literals as allowed when configuring the `constAllowed` value.