### PR TITLE
Optionally allow top-level `const` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 ## [Unreleased]
 
 - (`ebf23c6`) Always allow assignment of literals for `no-top-level-variables`.
+- (`282ff77`) Optionally allow top-level `const` assignments of functions.
 
 ## [2.2.1] - 2023-12-24
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -67,6 +67,17 @@ const answer = () => 42;
 const hello = (name) => `Hello ${name}!`;
 ```
 
+Examples of **correct** code when `'FunctionExpression'` is allowed:
+
+```javascript
+const answer = function () {
+  return 42;
+};
+const hello = function (name) {
+  return `Hello ${name}!`;
+};
+```
+
 Examples of **correct** code when `'Literal'` is allowed:
 
 ```javascript

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -20,13 +20,18 @@ const violationMessage = 'Variables at the top level are not allowed';
 const constAllowedValues = [
   'ArrayExpression',
   'ArrowFunctionExpression',
+  'FunctionExpression',
   'Literal',
   'MemberExpression',
   'ObjectExpression'
 ];
 const kindValues = ['const', 'let', 'var'];
 
-const defaultConstAllowed = ['ArrowFunctionExpression', 'MemberExpression'];
+const defaultConstAllowed = [
+  'ArrowFunctionExpression',
+  'FunctionExpression',
+  'MemberExpression'
+];
 const alwaysConstAllowed = ['Literal'];
 
 function isRequireCall(expression: Expression | null | undefined): boolean {

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -163,6 +163,25 @@ const valid: RuleTester.ValidTestCase[] = [
     code: `
       const s = Symbol();
     `
+  },
+  {
+    code: `
+      const foo = function() {
+        return 'bar';
+      }
+    `
+  },
+  {
+    code: `
+      const foo = function() {
+        return 'bar';
+      }
+    `,
+    options: [
+      {
+        constAllowed: ['FunctionExpression']
+      }
+    ]
   }
 ];
 
@@ -643,6 +662,27 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 28
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = function() {
+        return 'bar';
+      }
+    `,
+    options: [
+      {
+        constAllowed: []
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 3,
+        endColumn: 8
       }
     ]
   }


### PR DESCRIPTION
Relates to #737, #746, #750

## Summary

Adjust the reporting for `no-top-level-variables` to optionally allow assigning anonymous functions to top level `const`s. This is allowed by default because, similar to arrow functions.