### PR TITLE
Optionally allow top-level `const` template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning].
 
 - (`ebf23c6`) Always allow assignment of literals for `no-top-level-variables`.
 - (`282ff77`) Optionally allow top-level `const` assignments of functions.
+- (`f130b34`) Optionally allow top-level `const` assignments of template
+  literals.
 
 ## [2.2.1] - 2023-12-24
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -48,7 +48,7 @@ export default function () {
 This rule accepts a configuration object with two options:
 
 - `constAllowed`: Configure what assignments are allowed for `const`. By default
-  arrow functions, literals, and member expression assignments are allowed.
+  functions, literals, and member expression assignments are allowed.
 - `kind`: Configure which kinds of variables are forbidden. By default all of
   `const`, `let`, and `var` are forbidden.
 
@@ -97,6 +97,12 @@ Examples of **correct** code when `'ObjectExpression'` is allowed:
 
 ```javascript
 const obj = {foo: 'bar'};
+```
+
+Examples of **correct** code when `'TemplateLiteral'` is allowed:
+
+```javascript
+const foo = `bar`;
 ```
 
 #### kind

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -23,16 +23,18 @@ const constAllowedValues = [
   'FunctionExpression',
   'Literal',
   'MemberExpression',
-  'ObjectExpression'
+  'ObjectExpression',
+  'TemplateLiteral'
 ];
 const kindValues = ['const', 'let', 'var'];
 
 const defaultConstAllowed = [
   'ArrowFunctionExpression',
   'FunctionExpression',
-  'MemberExpression'
+  'MemberExpression',
+  'TemplateLiteral'
 ];
-const alwaysConstAllowed = ['Literal'];
+const alwaysConstAllowed = ['Literal', 'Identifier'];
 
 function isRequireCall(expression: Expression | null | undefined): boolean {
   return (
@@ -71,8 +73,6 @@ function checker(
           // type-coverage:ignore-next-line
           return isRequireCall(expression) || isSymbol(expression);
         }
-        case 'Identifier':
-          return true;
         default:
           return options.constAllowed.includes(t);
       }

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -182,6 +182,21 @@ const valid: RuleTester.ValidTestCase[] = [
         constAllowed: ['FunctionExpression']
       }
     ]
+  },
+  {
+    code: `
+      const foo = \`bar\`;
+    `
+  },
+  {
+    code: `
+      const foo = \`bar\`;
+    `,
+    options: [
+      {
+        constAllowed: ['TemplateLiteral']
+      }
+    ]
   }
 ];
 
@@ -683,6 +698,25 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 3,
         endColumn: 8
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = \`bar\`;
+    `,
+    options: [
+      {
+        constAllowed: []
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 18
       }
     ]
   }


### PR DESCRIPTION
Relates to #737, #746, #750, #752 

## Summary

Adjust the reporting for `no-top-level-variables` to optionally allow assigning template literals to top level `const`s. This is allowed by default because strings (one possibility of literals) are allowed by default as well. The fact that interpolation can be seen as a side effect should be handled by the `no-top-level-side-effects` rule instead