### PR TITLE
Allow user to disallow use of `require`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`33120d8`) Optionally disallow top-level side effect of calling `require`.
 
 ## [2.2.2] - 2023-12-24
 

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,6 +1,25 @@
 // SPDX-License-Identifier: ISC
 
 import type {Rule} from 'eslint';
+import type {Expression} from 'estree';
+
+export function isRequireCall(
+  expression: Expression | null | undefined
+): boolean {
+  return (
+    expression?.type === 'CallExpression' &&
+    expression.callee.type === 'Identifier' &&
+    expression.callee.name === 'require'
+  );
+}
+
+export function isSymbolCall(expression: Expression): boolean {
+  return (
+    expression.type === 'CallExpression' &&
+    expression.callee.type === 'Identifier' &&
+    expression.callee.name === 'Symbol'
+  );
+}
 
 export function isTopLevel(node: Rule.Node) {
   let scope = node.parent;

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -8,7 +8,7 @@ import type {
   VariableDeclarator
 } from 'estree';
 
-import {isTopLevel} from '../helpers';
+import {isRequireCall, isSymbolCall, isTopLevel} from '../helpers';
 
 type Options = {
   readonly constAllowed: ReadonlyArray<string>;
@@ -36,22 +36,6 @@ const defaultConstAllowed = [
 ];
 const alwaysConstAllowed = ['Literal', 'Identifier'];
 
-function isRequireCall(expression: Expression | null | undefined): boolean {
-  return (
-    expression?.type === 'CallExpression' &&
-    expression.callee.type === 'Identifier' &&
-    expression.callee.name === 'require'
-  );
-}
-
-function isSymbol(expression: Expression): boolean {
-  return (
-    expression.type === 'CallExpression' &&
-    expression.callee.type === 'Identifier' &&
-    expression.callee.name === 'Symbol'
-  );
-}
-
 function checker(
   context: Rule.RuleContext,
   options: Options,
@@ -71,7 +55,7 @@ function checker(
       switch (t) {
         case 'CallExpression': {
           // type-coverage:ignore-next-line
-          return isRequireCall(expression) || isSymbol(expression);
+          return isRequireCall(expression) || isSymbolCall(expression);
         }
         default:
           return options.constAllowed.includes(t);

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -594,6 +594,25 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 33
       }
     ]
+  },
+  {
+    code: `
+      const path = require('path');
+    `,
+    options: [
+      {
+        allowRequire: false
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 14,
+        endLine: 1,
+        endColumn: 29
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #747

## Summary

Update the `no-top-level-side-effects` rule with an option to disallow the use of `require`. This can be useful in non-CJS settings where for some reason `require` is an actual function. In this case you don't actually want to allow use of `require` at the top level.

To support this change, some refactoring has been carried out as well in order to reduce duplication.