### PR TITLE
Disallow several top-level side affects as part of declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning].
 
 ## [Unreleased]
 
+- (`7b50c22`) Disallow top-level side effects of async calls, binary operations,
+  conditional expression, logical operations, tagged template expressions, and
+  update expressions for `no-top-level-side-effects`.
 - (`33120d8`) Optionally disallow top-level side effect of calling `require`.
 
 ## [2.2.2] - 2023-12-24

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -76,8 +76,14 @@ function sideEffectInExpression(
   }
 
   if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'BinaryExpression' ||
     expression.type === 'CallExpression' ||
-    expression.type === 'NewExpression'
+    expression.type === 'ConditionalExpression' ||
+    expression.type === 'NewExpression' ||
+    expression.type === 'LogicalExpression' ||
+    expression.type === 'TaggedTemplateExpression' ||
+    expression.type === 'UpdateExpression'
   ) {
     context.report({
       node: expression,

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -613,13 +613,97 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 29
       }
     ]
+  },
+  {
+    code: `
+      const foo = await bar();
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 24
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = 1 + 2;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 18
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = x > 1 ? "a" : "b";
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 30
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = bar || baz;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 23
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = f\`bar\`;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 19
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = i++;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 16
+      }
+    ]
   }
 ];
 
 new RuleTester({
   parser,
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module'
   }
 }).run('no-top-level-side-effects', noTopLevelSideEffects, {


### PR DESCRIPTION
Relates to #740

## Summary

Update the `no-top-level-side-effects` rule to consider several expression types as side effects by default. Namely async calls (e.g. `await bar()`, binary operations (e.g. `1 + 2`), conditional expressions (e.g. `x ? y : z`), logical operations (e.g. `a || b`), tagged template expressions (e.g. 'f`foobar`'), and update expressions (e.g. `i++`).

For some of these I can see valid use cases that a user would want to allow (e.g. binary operations, to do `duration = 10 * 60` instead of `duration = 600`), but optionally allowing those is outside the scope of this commit.