### PR TITLE
Disallow top-level side affects as part of unary assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning].
 - (`7b50c22`) Disallow top-level side effects of async calls, binary operations,
   conditional expression, logical operations, tagged template expressions, and
   update expressions for `no-top-level-side-effects`.
+- (`b83307b`) Disallow top-level unary operations in assignments for
+  `no-top-level-side-effects`.
 - (`33120d8`) Optionally disallow top-level side effect of calling `require`.
 
 ## [2.2.2] - 2023-12-24

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -83,6 +83,8 @@ function sideEffectInExpression(
     expression.type === 'NewExpression' ||
     expression.type === 'LogicalExpression' ||
     expression.type === 'TaggedTemplateExpression' ||
+    (expression.type === 'UnaryExpression' &&
+      expression.argument.type !== 'Literal') ||
     expression.type === 'UpdateExpression'
   ) {
     context.report({

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -95,6 +95,11 @@ const valid: RuleTester.ValidTestCase[] = [
       let cp = require('child_process');
       const path = require('path');
     `
+  },
+  {
+    code: `
+      const foo = -1;
+    `
   }
 ];
 
@@ -695,6 +700,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 13,
         endLine: 1,
         endColumn: 16
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = -bar;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 17
       }
     ]
   }


### PR DESCRIPTION
Relates to #740, #758

## Summary

Update the `no-top-level-side-effects` rule to consider unary expression in assignments side effects (similar to binary expressions) but only if the argument isn't a literal, otherwise `-1` would be illegal.