### PR TITLE
Disallow top-level side affects as part of template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ Versioning].
 - (`7b50c22`) Disallow top-level side effects of async calls, binary operations,
   conditional expression, logical operations, tagged template expressions, and
   update expressions for `no-top-level-side-effects`.
-- (`b83307b`) Disallow top-level unary operations in assignments for
-  `no-top-level-side-effects`.
+- (`b83307b`) Disallow top-level unary operations with side effects in
+  assignments for `no-top-level-side-effects`.
+- (`c2866aa`) Disallow top-level template literals with side effects in
+  assignments for `no-top-level-side-effects`.
 - (`33120d8`) Optionally disallow top-level side effect of calling `require`.
 
 ## [2.2.2] - 2023-12-24

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -83,6 +83,8 @@ function sideEffectInExpression(
     expression.type === 'NewExpression' ||
     expression.type === 'LogicalExpression' ||
     expression.type === 'TaggedTemplateExpression' ||
+    (expression.type === 'TemplateLiteral' &&
+      expression.expressions.length > 0) ||
     (expression.type === 'UnaryExpression' &&
       expression.argument.type !== 'Literal') ||
     expression.type === 'UpdateExpression'

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -100,6 +100,11 @@ const valid: RuleTester.ValidTestCase[] = [
     code: `
       const foo = -1;
     `
+  },
+  {
+    code: `
+      const foo = \`bar\`;
+    `
   }
 ];
 
@@ -714,6 +719,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 13,
         endLine: 1,
         endColumn: 17
+      }
+    ]
+  },
+  {
+    code: `
+      const foo = \`\${bar}\`;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 21
       }
     ]
   }


### PR DESCRIPTION
Relates to #740, #758, #759 

## Summary

Update the `no-top-level-side-effects` rule to consider template literals with at least one expression a side effects (because it's similar to `"s1" + s2 + "s3"`). If the template literal doesn't contain any expressions it's just like normal string literals and thus allowed.