### PR TITLE
Rework the `no-top-level-variables` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning].
 
 ## [Unreleased v3]
 
+- (`6a79b0c`) _(Breaking)_ Rework the `no-top-level-side-effects` rule to make
+  it easier to configure.
 - (`207ad89`) _(Breaking)_ Rework the `no-top-level-variables` rule to focus on
   variables being mutable instead of other side effects.
 

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -1,10 +1,12 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # No top level side effect (no-top-level-side-effects)
 
 Disallow top level side effects.
 
-Side effects at the top level can have various negative side effects including
-but not limited to slow startup times and unexpected behaviour (in particular
-for libraries).
+Side effects at the top level can have some negative consequences such as slow
+startup times and, for libraries, unexpected behavior. This covers top level
+expression as well as assignments.
 
 ## Rule Details
 
@@ -67,12 +69,27 @@ module.exports = function () {
 
 This rule accepts a configuration object with one option:
 
+- `allowedCalls` Configure what function calls are allowed at the top level. Can
+  be any identifier. The default value covers standard JavaScript functions that
+  one might expect at the top level (such as `require`).
 - `allowIIFE: false` (default) Configure whether top level Immediately Invoked
-  Function Expressions are allowed.
-- `allowSymbol: true` (default) Configure whether top level assignments can call
-  `Symbol()`.
+  Function Expressions (IIFEs) are allowed.
 
-#### allowIIFE
+#### `allowedCalls`
+
+Example of **correct** code when `'f'` is in the list:
+
+```javascript
+function f() {}
+
+f();
+const x = f();
+export default f();
+```
+
+By setting this to an empty list you can disallow all top-level function calls.
+
+#### `allowIIFE`
 
 Examples of **correct** code when `'allowIIFE'` is set to `true`:
 
@@ -100,14 +117,6 @@ Examples of **correct** code when `'allowIIFE'` is set to `true`:
 
   fetch('/api').then((res) => res.text());
 })();
-```
-
-Examples of **correct** code when `'allowSymbol'` is set to `true`:
-
-```javascript
-var s1 = Symbol();
-let s2 = Symbol();
-const s3 = Symbol();
 ```
 
 ## When Not To Use It

--- a/tests/compat/snapshots.ts
+++ b/tests/compat/snapshots.ts
@@ -20,7 +20,7 @@ export const snapshots: ReadonlyArray<Snapshot> = [
 `
   },
   {
-    name: 'with top-level-side-effect violation',
+    name: 'with top-level-side-effects violation',
     inp: 'console.log("hello world");',
     out: `
 <text>

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -9,42 +9,6 @@ import {noTopLevelSideEffects} from '../../lib/rules/no-top-level-side-effects';
 const valid: RuleTester.ValidTestCase[] = [
   {
     code: `
-      (function() {
-        return '';
-      })();
-    `,
-    options: [
-      {
-        allowIIFE: true
-      }
-    ]
-  },
-  {
-    code: `
-      (() => {
-        return '';
-      })();
-    `,
-    options: [
-      {
-        allowIIFE: true
-      }
-    ]
-  },
-  {
-    code: `
-    export function foobar() {}
-    `
-  },
-  {
-    code: `
-      module.exports = {};
-      exports = {};
-      exports.foobar = {};
-    `
-  },
-  {
-    code: `
       function foobar() {
         if (foo === bar) {
           foo = "bar";
@@ -69,41 +33,145 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
-      export const hello = 'world';
+      class ClassName { }
+      function functionName() { }
+      function* generatorName() { }
+
+      const leet = 1337;
+      const bigInt = 1n;
+      const negative = -1;
+
+      const foo1 = 'bar';
+      const foo2 = "bar";
+      const foo3 = \`bar\`;
+
+      const foo = bar;
+      const isArray = Array.isArray;
+
+      const f = function() { };
+      const g = () => 'bar';
+
+      const { name1, name2: name3 } = o;
+      const [ name4, name5 ] = a;
     `
   },
   {
     code: `
-      const s1 = Symbol();
-      export const s2 = Symbol();
+      import defaultExport1 from "module-name";
+      import * as all1 from "module-name";
+      import { export1, export2 } from "module-name";
+      import { export3 as alias1, export4 } from "module-name";
+      import { default as alias2, export5 } from "module-name";
+      import { "string name" as alias3 } from "module-name";
+      import defaultExport2, { export6 } from "module-name";
+      import defaultExport3, * as all2 from "module-name";
+      import "module-name";
     `
   },
   {
     code: `
-      const s1 = Symbol();
-      export const s2 = Symbol();
-    `,
-    options: [
-      {
-        allowSymbol: true
-      }
-    ]
+      export class ClassName { }
+      export function functionName() { }
+      export function* generatorName() { }
+
+      export const leet = 1337;
+      export const bigInt = 1n;
+      export const negative = -1;
+
+      export const foo1 = 'bar';
+      export const foo2 = "bar";
+      export const foo3 = \`bar\`;
+
+      export const foo = bar;
+      export const isArray = Array.isArray;
+
+      export const f = function() { };
+      export const g = () => 'bar';
+
+      export const { o1, o2: o3 } = o;
+      export const [ a1, a2 ] = a;
+
+      const name1 = 0, name2 = 0, name3 = 0;
+      export { name1, name2 as name2a, name3 as "name 3" };
+
+      export * from "module-name";
+      export * as name4 from "module-name";
+      export { name5, name6 } from "module-name";
+      export { import1 as name7, import2 as name8, name9 } from "module-name";
+      export { default as name10, name11 } from "module-name";
+    `
+  },
+  {
+    code: `
+      const x = 0;
+      export { x as default };
+    `
+  },
+  {
+    code: `
+      export { default } from "module-name";
+    `
+  },
+  {
+    code: `
+      export default class ClassName { }
+    `
+  },
+  {
+    code: `
+      export default function f() { }
+    `
+  },
+  {
+    code: `
+      export default function* g() { }
+    `
+  },
+  {
+    code: `
+      export default class { }
+    `
+  },
+  {
+    code: `
+      export default function() { }
+    `
+  },
+  {
+    code: `
+      export default function* () { }
+    `
   },
   {
     code: `
       var fs = require('fs');
       let cp = require('child_process');
       const path = require('path');
+
+      const symbol1 = Symbol();
+      export const symbol2 = Symbol();
+
+      const bigInt1 = BigInt(1);
+      export const bigInt2 = BigInt(2);
     `
   },
   {
     code: `
-      const foo = -1;
-    `
+      (function() { return ''; })();
+      (() => { return ''; })();
+    `,
+    options: [
+      {
+        allowIIFE: true
+      }
+    ]
   },
+
   {
     code: `
-      const foo = \`bar\`;
+      module.exports = {};
+      exports = {};
+      exports.foobar = {};
     `
   }
 ];
@@ -111,240 +179,497 @@ const valid: RuleTester.ValidTestCase[] = [
 const invalid: RuleTester.InvalidTestCase[] = [
   {
     code: `
-      console.log('hello world');
+      do {
+        i++;
+      } while (i<10);
+      for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+        s += i;
+      }
+      for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+        s += i;
+      }
+      for (let i=0;i<10;i++) {
+        s += i;
+      }
+      if (foo) {
+        bar();
+      }
+      switch (foo) {
+      case 'bar':
+        break;
+      case 'baz':
+        break;
+      }
+      throw new Error('Hello world!');
+      try { } catch (e) { }
+      try { } catch (e) { } finally { }
+      while (i<10) {
+        i++;
+      }
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 1,
-        endLine: 1,
+        endLine: 3,
+        endColumn: 22
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 7,
+        endLine: 6,
+        endColumn: 8
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 7,
+        endLine: 9,
+        endColumn: 8
+      },
+      {
+        messageId: '0',
+        line: 10,
+        column: 7,
+        endLine: 12,
+        endColumn: 8
+      },
+      {
+        messageId: '0',
+        line: 13,
+        column: 7,
+        endLine: 15,
+        endColumn: 8
+      },
+      {
+        messageId: '0',
+        line: 16,
+        column: 7,
+        endLine: 21,
+        endColumn: 8
+      },
+      {
+        messageId: '0',
+        line: 22,
+        column: 7,
+        endLine: 22,
+        endColumn: 39
+      },
+      {
+        messageId: '0',
+        line: 23,
+        column: 7,
+        endLine: 23,
         endColumn: 28
+      },
+      {
+        messageId: '0',
+        line: 24,
+        column: 7,
+        endLine: 24,
+        endColumn: 40
+      },
+      {
+        messageId: '0',
+        line: 25,
+        column: 7,
+        endLine: 27,
+        endColumn: 8
       }
     ]
   },
   {
     code: `
-      for (let i=0;i<10;i++) {
-        s += i;
-      }
+      (function() { return ''; })();
+      (() => '')();
+
+      var v1 = (function() { })();
+      let v2 = (function() { })();
+      const v3 = (function() { })();
+      var v4 = (() => { })();
+      let v5 = (() => { })();
+      const v6 = (() => { })();
+
+      module.exports = (function() { })();
+      module.exports = (() => { })();
+
+      export const v7 = (function() { })();
+      export const v8 = (() => { })();
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 1,
+        endLine: 1,
+        endColumn: 31
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 7,
+        endLine: 2,
+        endColumn: 20
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 16,
+        endLine: 4,
+        endColumn: 34
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 16,
+        endLine: 5,
+        endColumn: 34
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 18,
+        endLine: 6,
+        endColumn: 36
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 16,
+        endLine: 7,
+        endColumn: 29
+      },
+      {
+        messageId: '0',
+        line: 8,
+        column: 16,
+        endLine: 8,
+        endColumn: 29
+      },
+      {
+        messageId: '0',
+        line: 9,
+        column: 18,
+        endLine: 9,
+        endColumn: 31
+      },
+      {
+        messageId: '0',
+        line: 11,
+        column: 24,
+        endLine: 11,
+        endColumn: 42
+      },
+      {
+        messageId: '0',
+        line: 12,
+        column: 24,
+        endLine: 12,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 14,
+        column: 25,
+        endLine: 14,
+        endColumn: 43
+      },
+      {
+        messageId: '0',
+        line: 15,
+        column: 25,
+        endLine: 15,
+        endColumn: 38
+      }
+    ]
+  },
+  {
+    code: `
+      var v1 = (function() { })();
+      let v2 = (function() { })();
+      const v3 = (function() { })();
+      var v4 = (() => { })();
+      let v5 = (() => { })();
+      const v6 = (() => { })();
+
+      module.exports = (function() { })();
+      module.exports = (() => { })();
+
+      export const v7 = (function() { })();
+      export const v8 = (() => { })();
+    `,
+    options: [
+      {
+        allowIIFE: true
+      }
+    ],
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 10,
+        endLine: 1,
+        endColumn: 28
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 16,
+        endLine: 2,
+        endColumn: 34
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 18,
         endLine: 3,
-        endColumn: 8
+        endColumn: 36
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 16,
+        endLine: 4,
+        endColumn: 29
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 16,
+        endLine: 5,
+        endColumn: 29
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 18,
+        endLine: 6,
+        endColumn: 31
+      },
+      {
+        messageId: '0',
+        line: 8,
+        column: 24,
+        endLine: 8,
+        endColumn: 42
+      },
+      {
+        messageId: '0',
+        line: 9,
+        column: 24,
+        endLine: 9,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 11,
+        column: 25,
+        endLine: 11,
+        endColumn: 43
+      },
+      {
+        messageId: '0',
+        line: 12,
+        column: 25,
+        endLine: 12,
+        endColumn: 38
+      }
+    ]
+  },
+  {
+    code: `
+      hello_world('hello world');
+
+      module.exports = hello_world('hello world');
+      export const hello = hello_world('hello world');
+      var foo1 = hello_world('bar1');
+      let foo2 = hello_world('bar2');
+      const foo3 = hello_world('bar3');
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 28
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 24,
+        endLine: 3,
+        endColumn: 50
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 28,
+        endLine: 4,
+        endColumn: 54
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 18,
+        endLine: 5,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 18,
+        endLine: 6,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 20,
+        endLine: 7,
+        endColumn: 39
+      }
+    ]
+  },
+  {
+    code: `
+      console.log('hello world');
+
+      module.exports = console.log('hello world');
+      export const hello = console.log('hello world');
+      var foo1 = console.log('bar1');
+      let foo2 = console.log('bar2');
+      const foo3 = console.log('bar3');
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 28
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 24,
+        endLine: 3,
+        endColumn: 50
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 28,
+        endLine: 4,
+        endColumn: 54
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 18,
+        endLine: 5,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 18,
+        endLine: 6,
+        endColumn: 37
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 20,
+        endLine: 7,
+        endColumn: 39
+      }
+    ]
+  },
+  {
+    code: `
+      new HelloWorld();
+
+      module.exports = new HelloWorld();
+      export const hello = new HelloWorld();
+      var foo1 = new Bar();
+      let foo2 = new Bar();
+      const foo3 = new Bar();
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 18
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 24,
+        endLine: 3,
+        endColumn: 40
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 28,
+        endLine: 4,
+        endColumn: 44
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 18,
+        endLine: 5,
+        endColumn: 27
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 18,
+        endLine: 6,
+        endColumn: 27
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 20,
+        endLine: 7,
+        endColumn: 29
       }
     ]
   },
   {
     code: `
       fetch('/api').then(res=>res.text()).then(console.log);
+      await fetch('/api');
+      const promised = await fetch('/api');
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 1,
         endLine: 1,
         endColumn: 55
-      }
-    ]
-  },
-  {
-    code: `
-      switch (foo) {}
-    `,
-    errors: [
+      },
       {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      {
-        console.log('hello world');
-      }
-    `,
-    errors: [
-      {
-        messageId: 'message',
+        messageId: '0',
         line: 2,
-        column: 9,
+        column: 7,
         endLine: 2,
-        endColumn: 36
-      }
-    ]
-  },
-  {
-    code: `
-      notModule.exports = {};
-    `,
-    errors: [
+        endColumn: 27
+      },
       {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      notExports = {};
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 17
-      }
-    ]
-  },
-  {
-    code: `
-      notExports.foobar = {};
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      do {
-        i++;
-        s += i;
-      } while (i<10);
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 4,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-        s += i;
-      }
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
+        messageId: '0',
+        line: 3,
+        column: 24,
         endLine: 3,
-        endColumn: 8
-      }
-    ]
-  },
-  {
-    code: `
-      for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-        s += i;
-      }
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 3,
-        endColumn: 8
-      }
-    ]
-  },
-  {
-    code: `
-      throw new Error('Hello world!');
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 33
-      }
-    ]
-  },
-  {
-    code: `
-      try { } catch (e) { }
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      try { } catch (e) { } finally { }
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 34
-      }
-    ]
-  },
-  {
-    code: `
-      (function() {
-        return '';
-      })();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 3,
-        endColumn: 12
-      }
-    ]
-  },
-  {
-    code: `
-      (() => {
-        return '';
-      })();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 1,
-        endLine: 3,
-        endColumn: 12
+        endColumn: 43
       }
     ]
   },
@@ -359,7 +684,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 1,
         endLine: 1,
@@ -369,212 +694,17 @@ const invalid: RuleTester.InvalidTestCase[] = [
   },
   {
     code: `
-      module.exports = console.log('hello world');
-      export const hello = console.log('hello world');
-      var foo1 = console.log('bar1');
-      let foo2 = console.log('bar2');
-      const foo3 = console.log('bar3');
-    `,
-    errors: [
       {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
-        endColumn: 44
-      },
-      {
-        messageId: 'message',
-        line: 2,
-        column: 28,
-        endLine: 2,
-        endColumn: 54
-      },
-      {
-        messageId: 'message',
-        line: 3,
-        column: 18,
-        endLine: 3,
-        endColumn: 37
-      },
-      {
-        messageId: 'message',
-        line: 4,
-        column: 18,
-        endLine: 4,
-        endColumn: 37
-      },
-      {
-        messageId: 'message',
-        line: 5,
-        column: 20,
-        endLine: 5,
-        endColumn: 39
+        console.log('hello world');
       }
-    ]
-  },
-  {
-    code: `
-      module.exports = (function() { })();
-      export const hello = (function() { })();
-      var foo1 = (function() { })();
-      let foo2 = (function() { })();
-      const foo3 = (function() { })();
     `,
     errors: [
       {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
+        messageId: '0',
+        line: 2,
+        column: 9,
+        endLine: 2,
         endColumn: 36
-      },
-      {
-        messageId: 'message',
-        line: 2,
-        column: 28,
-        endLine: 2,
-        endColumn: 46
-      },
-      {
-        messageId: 'message',
-        line: 3,
-        column: 18,
-        endLine: 3,
-        endColumn: 36
-      },
-      {
-        messageId: 'message',
-        line: 4,
-        column: 18,
-        endLine: 4,
-        endColumn: 36
-      },
-      {
-        messageId: 'message',
-        line: 5,
-        column: 20,
-        endLine: 5,
-        endColumn: 38
-      }
-    ]
-  },
-  {
-    code: `
-      module.exports = (() => { })();
-      export const hello = (() => { })();
-      var foo1 = (() => { })();
-      let foo2 = (() => { })();
-      const foo3 = (() => { })();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
-        endColumn: 31
-      },
-      {
-        messageId: 'message',
-        line: 2,
-        column: 28,
-        endLine: 2,
-        endColumn: 41
-      },
-      {
-        messageId: 'message',
-        line: 3,
-        column: 18,
-        endLine: 3,
-        endColumn: 31
-      },
-      {
-        messageId: 'message',
-        line: 4,
-        column: 18,
-        endLine: 4,
-        endColumn: 31
-      },
-      {
-        messageId: 'message',
-        line: 5,
-        column: 20,
-        endLine: 5,
-        endColumn: 33
-      }
-    ]
-  },
-  {
-    code: `
-      module.exports = new HelloWorld();
-      export const hello = new HelloWorld();
-      var foo1 = new Bar();
-      let foo2 = new Bar();
-      const foo3 = new Bar();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 18,
-        endLine: 1,
-        endColumn: 34
-      },
-      {
-        messageId: 'message',
-        line: 2,
-        column: 28,
-        endLine: 2,
-        endColumn: 44
-      },
-      {
-        messageId: 'message',
-        line: 3,
-        column: 18,
-        endLine: 3,
-        endColumn: 27
-      },
-      {
-        messageId: 'message',
-        line: 4,
-        column: 18,
-        endLine: 4,
-        endColumn: 27
-      },
-      {
-        messageId: 'message',
-        line: 5,
-        column: 20,
-        endLine: 5,
-        endColumn: 29
-      }
-    ]
-  },
-  {
-    code: `
-      const f1 = f();
-      export const f2 = f();
-    `,
-    options: [
-      {
-        allowSymbol: true
-      }
-    ],
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 12,
-        endLine: 1,
-        endColumn: 15
-      },
-      {
-        messageId: 'message',
-        line: 2,
-        column: 25,
-        endLine: 2,
-        endColumn: 28
       }
     ]
   },
@@ -585,19 +715,19 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     options: [
       {
-        allowSymbol: false
+        allowedCalls: []
       }
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 12,
         endLine: 1,
         endColumn: 20
       },
       {
-        messageId: 'message',
+        messageId: '0',
         line: 2,
         column: 25,
         endLine: 2,
@@ -611,12 +741,12 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     options: [
       {
-        allowRequire: false
+        allowedCalls: []
       }
     ],
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 14,
         endLine: 1,
@@ -626,25 +756,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
   },
   {
     code: `
-      const foo = await bar();
-    `,
-    errors: [
-      {
-        messageId: 'message',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
       const foo = 1 + 2;
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -658,7 +774,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -672,7 +788,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -686,7 +802,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -700,7 +816,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -714,7 +830,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
@@ -728,11 +844,54 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     errors: [
       {
-        messageId: 'message',
+        messageId: '0',
         line: 1,
         column: 13,
         endLine: 1,
         endColumn: 21
+      }
+    ]
+  },
+
+  {
+    code: `
+      notModule.exports = {};
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 24
+      }
+    ]
+  },
+  {
+    code: `
+      notExports = {};
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 17
+      }
+    ]
+  },
+  {
+    code: `
+      notExports.foobar = {};
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 24
       }
     ]
   }


### PR DESCRIPTION
Relates to #750 
Merges into #761

## Summary

Update the `no-top-level-side-effects` rule to be easier to work with by changing the configuration so that it is more easily extended for different use cases.

Other than that this refactors and re-organizes the rules and its tests with the aim of simplifying.