### PR TITLE
Handle `ChainExpression`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning].
   variables being mutable instead of other side effects.
 - (`a3c513e`) Allow for configuring which classes can be instantiated at the top
   level for `no-top-level-side-effects`.
+- (`7dd470f`) Disallow top-level side effects of optional changing for
+  `no-top-level-side-effects`.
 
 ## [Unreleased v2]
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -92,6 +92,7 @@ function sideEffectInExpression(
     expression.type === 'BinaryExpression' ||
     (expression.type === 'CallExpression' &&
       !options.allowedCalls.some((name) => isCallTo(expression, name))) ||
+    expression.type === 'ChainExpression' ||
     expression.type === 'ConditionalExpression' ||
     (expression.type === 'NewExpression' &&
       !options.allowedNews.some((name) => isNew(expression, name))) ||

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -29,7 +29,6 @@ const disallowedConst = {
 
 const allowedValues = [
   'ArrayExpression',
-  'ChainExpression',
   'ImportExpression',
   'ObjectExpression',
   'SequenceExpression',
@@ -43,6 +42,7 @@ const allowedAlways = [
   'AwaitExpression',
   'BinaryExpression',
   'CallExpression',
+  'ChainExpression',
   'ConditionalExpression',
   'FunctionExpression',
   'Identifier',

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -906,6 +906,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
       }
     ]
   },
+  {
+    code: `
+      const foo = bar?.baz;
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 21
+      }
+    ]
+  },
 
   {
     code: `

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -70,6 +70,7 @@ const valid: RuleTester.ValidTestCase[] = [
       const unary = -bar;
       const update = i++;
       const ternary = bar ? bar : baz;
+      const chain = foo?.bar;
 
       const f = function() { };
       const g = () => 'bar';
@@ -110,6 +111,7 @@ const valid: RuleTester.ValidTestCase[] = [
       export const unary = -bar;
       export const update = i++;
       export const ternary = bar ? bar : baz;
+      export const chain = foo?.bar;
 
       export const f = function() { };
       export const g = () => 'bar';


### PR DESCRIPTION
Merges into #761

## Summary

Update the `no-top-level-variables` rule to not consider these a problem because they don't say anything about the variable itself.

Update the `no-top-level-side-effects` rule to do consider these a problem because they are a side effect similar to ternary operators.