### PR TITLE
Handle `ChainExpressions` in assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`2f2bb41`) Disallow top-level side effects of optional changing for
+  `no-top-level-side-effects`.
 
 ## [2.3.0] - 2023-12-25
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -78,6 +78,7 @@ function sideEffectInExpression(
     expression.type === 'AwaitExpression' ||
     expression.type === 'BinaryExpression' ||
     expression.type === 'CallExpression' ||
+    expression.type === 'ChainExpression' ||
     expression.type === 'ConditionalExpression' ||
     expression.type === 'NewExpression' ||
     expression.type === 'LogicalExpression' ||

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -15,6 +15,7 @@ const violationMessage = 'Variables at the top level are not allowed';
 const constAllowedValues = [
   'ArrayExpression',
   'ArrowFunctionExpression',
+  'ChainExpression',
   'FunctionExpression',
   'Literal',
   'MemberExpression',

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -741,6 +741,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 21
       }
     ]
+  },
+  {
+    code: `
+      const foo = bar?.baz;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 21
+      }
+    ]
   }
 ];
 

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -213,6 +213,16 @@ const valid: RuleTester.ValidTestCase[] = [
       const name1 = 0;
       export { name1 };
     `
+  },
+  {
+    code: `
+      const chain = foo?.bar;
+    `,
+    options: [
+      {
+        constAllowed: ['ChainExpression']
+      }
+    ]
   }
 ];
 
@@ -733,6 +743,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 7,
         endLine: 1,
         endColumn: 18
+      }
+    ]
+  },
+  {
+    code: `
+      const chain = foo?.bar;
+    `,
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 7,
+        endLine: 1,
+        endColumn: 23
       }
     ]
   }


### PR DESCRIPTION
Supersedes #768

## Summary

Update the `no-top-level-variables` rule to optionally not consider these a problem because they don't say anything about the variable itself.

Update the `no-top-level-side-effects` rule to do consider these a problem because they are a side effect similar to ternary operators.