### PR TITLE
Allow user to disallow use of `module.exports` (and `exports`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning].
   `no-top-level-side-effects`.
 - (`2f2bb41`) Fix bug where `module.exports.property`-like assignments were not
   allowed by `no-top-level-side-effects`.
+- (`0e04f54`) Optionally disallow top-level side effect of assigning to either
+  of `module.exports` or `exports`.
 
 ## [2.3.0] - 2023-12-25
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -10,6 +10,7 @@ import type {
 import {isRequireCall, isSymbolCall, isTopLevel} from '../helpers';
 
 type Options = {
+  readonly allowExports: boolean;
   readonly allowIIFE: boolean;
   readonly allowRequire: boolean;
   readonly allowSymbol: boolean;
@@ -131,6 +132,9 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
       {
         type: 'object',
         properties: {
+          allowModuleExports: {
+            type: 'boolean'
+          },
           allowIIFE: {
             type: 'boolean'
           },
@@ -146,16 +150,20 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
   },
   create: (context) => {
     // type-coverage:ignore-next-line
-    const [providedOptions] = context.options;
+    const [provided] = context.options;
 
     // type-coverage:ignore-next-line
-    const providedAllowIIFE: boolean | null = providedOptions?.allowIIFE;
+    const providedAllowExports: boolean | null = provided?.allowModuleExports;
     // type-coverage:ignore-next-line
-    const providedAllowRequire: boolean | null = providedOptions?.allowRequire;
+    const providedAllowIIFE: boolean | null = provided?.allowIIFE;
     // type-coverage:ignore-next-line
-    const providedAllowSymbol: boolean | null = providedOptions?.allowSymbol;
+    const providedAllowRequire: boolean | null = provided?.allowRequire;
+    // type-coverage:ignore-next-line
+    const providedAllowSymbol: boolean | null = provided?.allowSymbol;
 
     const options: Options = {
+      allowExports:
+        typeof providedAllowExports === 'boolean' ? providedAllowExports : true,
       allowIIFE:
         typeof providedAllowIIFE === 'boolean' ? providedAllowIIFE : false,
       allowRequire:
@@ -183,10 +191,11 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
             });
           }
         } else if (
-          isExportsAssignment(node) ||
-          isExportPropertyAssignment(node) ||
-          isModuleAssignment(node) ||
-          isModulePropertyAssignment(node)
+          options.allowExports &&
+          (isExportsAssignment(node) ||
+            isExportPropertyAssignment(node) ||
+            isModuleAssignment(node) ||
+            isModulePropertyAssignment(node))
         ) {
           if (node.expression.type === 'AssignmentExpression') {
             sideEffectInExpression(context, options, node.expression.right);

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -112,6 +112,19 @@ const valid: RuleTester.ValidTestCase[] = [
       const name1 = 0;
       export { name1 };
     `
+  },
+  {
+    code: `
+      module.exports = {};
+      module.exports.foobar = {};
+      exports = {};
+      exports.foobar = {};
+    `,
+    options: [
+      {
+        allowModuleExports: true
+      }
+    ]
   }
 ];
 
@@ -782,6 +795,49 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 13,
         endLine: 1,
         endColumn: 21
+      }
+    ]
+  },
+  {
+    code: `
+      module.exports = {};
+      module.exports.foobar = {};
+      exports = {};
+      exports.foobar = {};
+    `,
+    options: [
+      {
+        allowModuleExports: false
+      }
+    ],
+    errors: [
+      {
+        messageId: 'message',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 21
+      },
+      {
+        messageId: 'message',
+        line: 2,
+        column: 7,
+        endLine: 2,
+        endColumn: 34
+      },
+      {
+        messageId: 'message',
+        line: 3,
+        column: 7,
+        endLine: 3,
+        endColumn: 20
+      },
+      {
+        messageId: 'message',
+        line: 4,
+        column: 7,
+        endLine: 4,
+        endColumn: 27
       }
     ]
   }


### PR DESCRIPTION
Relates to #757, #770

## Summary

Update the `no-top-level-side-effects` rule with an option to disallow the use of `module.exports` and `exports`. This can be useful in non-CJS settings, where you don't want to allow using these at the top level.