### PR TITLE
Introduce `commonjs` option for `no-top-level-side-effects`

### DIFF
--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -71,11 +71,14 @@ This rule accepts a configuration object with one option:
 
 - `allowedCalls` Configure what function calls are allowed at the top level. Can
   be any identifier. The default value covers standard JavaScript functions that
-  one might expect at the top level (such as `require`).
+  one might expect at the top level (such as `Bigint` and `Symbol`).
 - `allowedNews` Configure what classes can be instantiated at the top level. Can
   be any identifier.
 - `allowIIFE: false` (default) Configure whether top level Immediately Invoked
   Function Expressions (IIFEs) are allowed.
+- `commonjs: false` (default) Configure whether the code being analyzed is, or
+  is partially, CommonJS code. Allows for using `require`, `module.exports` and
+  `exports` at the top level.
 
 #### `allowedCalls`
 
@@ -130,6 +133,21 @@ Examples of **correct** code when `'allowIIFE'` is set to `true`:
 
   fetch('/api').then((res) => res.text());
 })();
+```
+
+#### `commonjs`
+
+Examples of **correct** code when `'commonjs'` is set to `true`:
+
+```javascript
+var cp = require('child_process');
+let fs = require('fs');
+const path = require('path');
+
+module.exports = {};
+module.exports.foo = 'bar';
+exports = {};
+exports.foo = 'bar';
 ```
 
 ## When Not To Use It

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -148,49 +148,12 @@ const valid: RuleTester.ValidTestCase[] = [
   },
   {
     code: `
-      module.exports = {};
-      module.exports.foobar = {};
-      exports = {};
-      exports.foobar = {};
-    `
-  },
-  {
-    code: `
-      module.exports = {};
-      module.exports.foobar = {};
-      exports = {};
-      exports.foobar = {};
-    `,
-    options: [
-      {
-        allowModuleExports: true
-      }
-    ]
-  },
-  {
-    code: `
-      var fs = require('fs');
-      let cp = require('child_process');
-      const path = require('path');
-
       const symbol1 = Symbol();
       export const symbol2 = Symbol();
 
       const bigInt1 = BigInt(1);
       export const bigInt2 = BigInt(2);
     `
-  },
-  {
-    code: `
-      var fs = require('fs');
-      let cp = require('child_process');
-      const path = require('path');
-    `,
-    options: [
-      {
-        allowedCalls: ['require']
-      }
-    ]
   },
   {
     code: `
@@ -233,6 +196,23 @@ const valid: RuleTester.ValidTestCase[] = [
     options: [
       {
         allowIIFE: true
+      }
+    ]
+  },
+  {
+    code: `
+      var fs = require('fs');
+      let cp = require('child_process');
+      const path = require('path');
+
+      module.exports = {};
+      module.exports.foobar = {};
+      exports = {};
+      exports.foobar = {};
+    `,
+    options: [
+      {
+        commonjs: true
       }
     ]
   }
@@ -360,6 +340,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
       export const v7 = (function() { })();
       export const v8 = (() => { })();
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -464,7 +449,8 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     options: [
       {
-        allowIIFE: true
+        allowIIFE: true,
+        commonjs: true
       }
     ],
     errors: [
@@ -550,6 +536,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
       let foo2 = hello_world('bar2');
       const foo3 = hello_world('bar3');
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -605,6 +596,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
       let foo2 = console.log('bar2');
       const foo3 = console.log('bar3');
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -662,7 +658,8 @@ const invalid: RuleTester.InvalidTestCase[] = [
     `,
     options: [
       {
-        allowedNews: ['Map', 'Set']
+        allowedNews: ['Map', 'Set'],
+        commonjs: true
       }
     ],
     errors: [
@@ -940,9 +937,47 @@ const invalid: RuleTester.InvalidTestCase[] = [
       exports = {};
       exports.foobar = {};
     `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 21
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 7,
+        endLine: 2,
+        endColumn: 34
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 7,
+        endLine: 3,
+        endColumn: 20
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 7,
+        endLine: 4,
+        endColumn: 27
+      }
+    ]
+  },
+  {
+    code: `
+      module.exports = {};
+      module.exports.foobar = {};
+      exports = {};
+      exports.foobar = {};
+    `,
     options: [
       {
-        allowModuleExports: false
+        commonjs: false
       }
     ],
     errors: [
@@ -980,6 +1015,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     code: `
       notModule.exports = {};
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -994,6 +1034,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     code: `
       notExports = {};
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -1008,6 +1053,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     code: `
       notExports.foobar = {};
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -1022,6 +1072,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     code: `
       notModule.exports.foobar = {};
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',
@@ -1036,6 +1091,11 @@ const invalid: RuleTester.InvalidTestCase[] = [
     code: `
       module.notExports.foobar = {};
     `,
+    options: [
+      {
+        commonjs: true
+      }
+    ],
     errors: [
       {
         messageId: '0',


### PR DESCRIPTION
Relates to #757, #771, 6a79b0c4f8ee751ec5c17bae79b3033fc06a7fe2
Merges into #761

## Summary

Update the `no-top-level-side-effects` rule to omit the `allowExports`
option and instead adopt the `commonjs` option. This new option allows
managing whether all of `require`, `module.exports`, and `exports` are
allowed. When set to true, they're all allowed (`module.exports` and
`exports` are handled as before, `require` is injected into the list of
allowed functions to call).

This option is off by default to encourage the use of ESM and to avoid
false negatives in ESM code.