### PR TITLE
Use lockfile-lint to vet `package-lock.json`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -360,6 +360,9 @@ jobs:
       - name: Vet package manifest
         if: ${{ failure() || success() }}
         run: npm run vet:package.json
+      - name: Vet lockfile
+        if: ${{ failure() || success() }}
+        run: npm run vet:package-lock.json
       - name: Vet types
         if: ${{ failure() || success() }}
         run: npm run vet:types

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "is-ci": "3.0.1",
         "knip": "3.8.4",
         "licensee": "10.0.0",
+        "lockfile-lint": "4.12.1",
         "markdownlint-cli": "0.38.0",
         "mocha": "10.2.0",
         "nve": "17.0.0",
@@ -2754,6 +2755,41 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@yarnpkg/parsers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0.tgz",
+      "integrity": "sha512-jVZa3njBv6tcOUw34nlUdUM/40wwtm/gnVF8rtk0tA6vNcokqYI8CFU1BZjlpFwUSZaXxYkrtuPE/f2MMFlTxQ==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@zkochan/retry": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@zkochan/retry/-/retry-0.2.0.tgz",
@@ -4026,6 +4062,32 @@
         "spdx-expression-validate": "^2.0.0"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4935,6 +4997,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -6827,6 +6902,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lockfile-lint": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-4.12.1.tgz",
+      "integrity": "sha512-FBP7OA7sa45kzPgRNLYIcGGgDS86rpZNW3ptALp1vlzv+oHZsqFZdmHXM4N4FwiGXHzUOpSVvDLT4v7IiQXFtA==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^8.2.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.1",
+        "lockfile-lint-api": "^5.8.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "lockfile-lint": "bin/lockfile-lint.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lockfile-lint-api": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.8.0.tgz",
+      "integrity": "sha512-RHa+ofSGMGQvPFG1oD2qZmSWF2MfxWXhle/unpzmDjpi8F8Ou5sreNUcAscgGRfcX+BszBuVKddD0X5YKQ0TeA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/parsers": "^3.0.0-rc.32",
+        "debug": "^4.3.4",
+        "object-hash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -8562,6 +8670,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -10634,6 +10751,12 @@
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/ssri": {
       "version": "10.0.5",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "is-ci": "3.0.1",
     "knip": "3.8.4",
     "licensee": "10.0.0",
+    "lockfile-lint": "4.12.1",
     "markdownlint-cli": "0.38.0",
     "mocha": "10.2.0",
     "nve": "17.0.0",
@@ -87,9 +88,10 @@
     "test:mutation": "stryker run stryker.config.js",
     "test:watch": "npm run test -- --watch",
     "verify": "npm run build && npm run format:check && npm run lint && npm run test && npm run vet",
-    "vet": "npm run vet:imports && npm run vet:package.json && npm run vet:types",
+    "vet": "npm run vet:imports && npm run vet:package.json && npm run vet:package-lock.json && npm run vet:types",
     "vet:imports": "knip --config knip.jsonc",
     "vet:package.json": "npm run build && publint run --strict",
+    "vet:package-lock.json": "lockfile-lint --path package-lock.json --allowed-hosts npm --validate-https",
     "vet:types": "type-coverage --at-least 100 --cache --cache-directory .cache --project tsconfig.json --strict"
   }
 }


### PR DESCRIPTION
Relates to #633

## Summary

Start vetting(/linting) the lockfile for problems using [lockfile-lint](https://www.npmjs.com/package/lockfile-lint). In particular, with the current configuration this checks that only listed sources are used for packages as well as that only `https` is used.