### PR TITLE
Add option to allow derivations as `top-level-side-effects`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`b833db9`) Add option to allow deriving values at the top level as a side
+  effect.
 
 ## [3.0.0] - 2023-12-27
 

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -76,6 +76,9 @@ This rule accepts a configuration object with four options:
   be any identifier. By default no classes can be instantiated.
 - `allowIIFE: false` (default) Configure whether top level Immediately Invoked
   Function Expressions (IIFEs) are allowed.
+- `allowDerived: false` (default) Configure whether derivations - binary,
+  logical, or unary operations on values and variables - are allowed at the top
+  level.
 - `commonjs: false` (default) Configure whether the code being analyzed is, or
   is partially, CommonJS code. Allows the use `require`, `module.exports` and
   `exports` at the top level.
@@ -133,6 +136,47 @@ Examples of **correct** code when `'allowIIFE'` is set to `true`:
 
   fetch('/api').then((res) => res.text());
 })();
+```
+
+#### `allowDerived`
+
+Examples of **correct** code when `'allowDerived'` is set to `true`:
+
+```javascript
+const a = 0; // (always allowed)
+const b = 1; // (always allowed)
+
+const b01 = a == b;
+const b02 = a != b;
+const b03 = a === b;
+const b04 = a !== b;
+const b05 = a < b;
+const b06 = a <= b;
+const b07 = a > b;
+const b08 = a >= b;
+const b09 = a << b;
+const b10 = a >> b;
+const b11 = a >>> b;
+const b12 = a + b;
+const b13 = a - b;
+const b14 = a * b;
+const b15 = a / b;
+const b16 = a % b;
+const b17 = a ** b;
+const b18 = a | b;
+const b19 = a ^ b;
+const b20 = a & b;
+const b21 = a in b;
+const b22 = a instanceof b;
+
+const l01 = a && b;
+const l02 = a || b;
+const l03 = a ?? b;
+
+const u01 = -a;
+const u02 = +a;
+const u03 = !a;
+const u04 = ~a;
 ```
 
 #### `commonjs`

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -216,6 +216,46 @@ const valid: RuleTester.ValidTestCase[] = [
         commonjs: true
       }
     ]
+  },
+  {
+    code: `
+      const b01 = a == b;
+      const b02 = a != b;
+      const b03 = a === b;
+      const b04 = a !== b;
+      const b05 = a < b;
+      const b06 = a <= b;
+      const b07 = a > b;
+      const b08 = a >= b;
+      const b09 = a << b;
+      const b10 = a >> b;
+      const b11 = a >>> b;
+      const b12 = a + b;
+      const b13 = a - b;
+      const b14 = a * b;
+      const b15 = a / b;
+      const b16 = a % b;
+      const b17 = a ** b;
+      const b18 = a | b;
+      const b19 = a ^ b;
+      const b20 = a & b;
+      const b21 = a in b;
+      const b22 = a instanceof b;
+
+      const l01 = a && b;
+      const l02 = a || b;
+      const l03 = a ?? b;
+
+      const u01 = -a;
+      const u02 = +a;
+      const u03 = !a;
+      const u04 = ~a;
+    `,
+    options: [
+      {
+        allowDerived: true
+      }
+    ]
   }
 ];
 
@@ -1135,6 +1175,247 @@ const invalid: RuleTester.InvalidTestCase[] = [
         column: 1,
         endLine: 1,
         endColumn: 31
+      }
+    ]
+  },
+  {
+    code: `
+      const b01 = a == b;
+      const b02 = a != b;
+      const b03 = a === b;
+      const b04 = a !== b;
+      const b05 = a < b;
+      const b06 = a <= b;
+      const b07 = a > b;
+      const b08 = a >= b;
+      const b09 = a << b;
+      const b10 = a >> b;
+      const b11 = a >>> b;
+      const b12 = a + b;
+      const b13 = a - b;
+      const b14 = a * b;
+      const b15 = a / b;
+      const b16 = a % b;
+      const b17 = a ** b;
+      const b18 = a | b;
+      const b19 = a ^ b;
+      const b20 = a & b;
+      const b21 = a in b;
+      const b22 = a instanceof b;
+
+      const l01 = a && b;
+      const l02 = a || b;
+      const l03 = a ?? b;
+
+      const u01 = -a;
+      const u02 = +a;
+      const u03 = !a;
+      const u04 = ~a;
+    `,
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 13,
+        endLine: 1,
+        endColumn: 19
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 19,
+        endLine: 2,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 19,
+        endLine: 3,
+        endColumn: 26
+      },
+      {
+        messageId: '0',
+        line: 4,
+        column: 19,
+        endLine: 4,
+        endColumn: 26
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 19,
+        endLine: 5,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 19,
+        endLine: 6,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 19,
+        endLine: 7,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 8,
+        column: 19,
+        endLine: 8,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 9,
+        column: 19,
+        endLine: 9,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 10,
+        column: 19,
+        endLine: 10,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 11,
+        column: 19,
+        endLine: 11,
+        endColumn: 26
+      },
+      {
+        messageId: '0',
+        line: 12,
+        column: 19,
+        endLine: 12,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 13,
+        column: 19,
+        endLine: 13,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 14,
+        column: 19,
+        endLine: 14,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 15,
+        column: 19,
+        endLine: 15,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 16,
+        column: 19,
+        endLine: 16,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 17,
+        column: 19,
+        endLine: 17,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 18,
+        column: 19,
+        endLine: 18,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 19,
+        column: 19,
+        endLine: 19,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 20,
+        column: 19,
+        endLine: 20,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 21,
+        column: 19,
+        endLine: 21,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 22,
+        column: 19,
+        endLine: 22,
+        endColumn: 33
+      },
+      {
+        messageId: '0',
+        line: 24,
+        column: 19,
+        endLine: 24,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 25,
+        column: 19,
+        endLine: 25,
+        endColumn: 25
+      },
+      {
+        messageId: '0',
+        line: 26,
+        column: 19,
+        endLine: 26,
+        endColumn: 25
+      },
+
+      {
+        messageId: '0',
+        line: 28,
+        column: 19,
+        endLine: 28,
+        endColumn: 21
+      },
+      {
+        messageId: '0',
+        line: 29,
+        column: 19,
+        endLine: 29,
+        endColumn: 21
+      },
+      {
+        messageId: '0',
+        line: 30,
+        column: 19,
+        endLine: 30,
+        endColumn: 21
+      },
+      {
+        messageId: '0',
+        line: 31,
+        column: 19,
+        endLine: 31,
+        endColumn: 21
       }
     ]
   }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -1418,6 +1418,89 @@ const invalid: RuleTester.InvalidTestCase[] = [
         endColumn: 21
       }
     ]
+  },
+  {
+    code: `
+      const bLeft = f() + b;
+      const bRight = a - g();
+      const bBoth = f() * g();
+
+      const lLeft = f() && b;
+      const lRight = a || g();
+      const lBoth = f() ?? g();
+
+      const u = -f();
+    `,
+    options: [
+      {
+        allowDerived: true
+      }
+    ],
+    errors: [
+      {
+        messageId: '0',
+        line: 1,
+        column: 15,
+        endLine: 1,
+        endColumn: 18
+      },
+      {
+        messageId: '0',
+        line: 2,
+        column: 26,
+        endLine: 2,
+        endColumn: 29
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 21,
+        endLine: 3,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 3,
+        column: 27,
+        endLine: 3,
+        endColumn: 30
+      },
+      {
+        messageId: '0',
+        line: 5,
+        column: 21,
+        endLine: 5,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 6,
+        column: 27,
+        endLine: 6,
+        endColumn: 30
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 21,
+        endLine: 7,
+        endColumn: 24
+      },
+      {
+        messageId: '0',
+        line: 7,
+        column: 28,
+        endLine: 7,
+        endColumn: 31
+      },
+      {
+        messageId: '0',
+        line: 9,
+        column: 18,
+        endLine: 9,
+        endColumn: 21
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Relates to #764, #767, #773

## Summary

Update the `top-level-side-effects` rule to include an option that enables users to allow top-level declarations to perform side-effect free operations on values and variables. This is disabled by default because the act of performing the derivation is a side effect. However, because there's no side effects to the derivations and because it can be useful (e.g. `const timeout = 24 * 60 * 60` might be easier to read), users are given the ability to allow these in their code base if they so choose.