### PR TITLE
Update labeler config for documentation label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,8 @@ dependencies:
 documentation:
   - changed-files:
       - any-glob-to-any-file:
-          - docs/*
+          - docs/**
+          - docs/**/*
           - README.md
 
 meta:


### PR DESCRIPTION
Relates to #785, where I noticed the [documentation label](https://github.com/ericcornelissen/eslint-plugin-top/labels/documentation) wasn't being added automatically.