### PR TITLE
Remove references to (main-)v2 given its EOL

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-      - main-v2
-      - v2
       - v3
 
 permissions: read-all

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - main-v2
-      - v2
       - v3
 
 permissions: read-all

--- a/.github/workflows/config-codecov.yml
+++ b/.github/workflows/config-codecov.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - main-v2
     paths:
       - .github/workflows/config-codecov.yml
       - .github/codecov.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     name: Audit
     uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main
     with:
-      refs: '["main", "main-v2", "v2", "v3"]'
+      refs: '["main", "v3"]'
   tooling:
     name: Update tooling
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - main-v2
 
 permissions: read-all
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - main-v2
 
 permissions: read-all
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,6 @@ relevant sections of this document.
   - [Workflow](#workflow)
   - [Development Details](#development-details)
 
-> [!NOTE]
-> If you want to make a contribution to v2 of the project, please refer to the
-> [Contributing Guidelines for v2].
-
 ---
 
 ## Reporting Issues
@@ -238,7 +234,6 @@ This will create a file called `index.js`. Note that this file ignored by git.
 [actionlint]: https://github.com/rhysd/actionlint
 [better-npm-audit]: https://www.npmjs.com/package/better-npm-audit
 [bug report]: https://github.com/ericcornelissen/eslint-plugin-top/issues/new?labels=bug
-[contributing guidelines for v2]: https://github.com/ericcornelissen/eslint-plugin-top/blob/main-v2/CONTRIBUTING.md
 [editorconfig]: https://editorconfig.org/
 [eslint]: https://eslint.org/
 [eslint-plugin-json]: https://www.npmjs.com/package/eslint-plugin-json


### PR DESCRIPTION
Relates to #905

## Summary

Update the `main` branch to omit references to v2 which will no longer be supported starting 2024-03-26.