### PR TITLE
One case per test

### DIFF
--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -6,1502 +6,2102 @@ import {RuleTester} from 'eslint';
 import {trimTestCases} from './helpers';
 import {noTopLevelSideEffects} from '../../lib/rules/no-top-level-side-effects';
 
-const valid: RuleTester.ValidTestCase[] = [
-  {
-    code: `
-      function foobar() {
-        if (foo === bar) {
-          foo = "bar";
-        }
-
-        for (let i = 0; i < 2; i++) {
-          foo = bar[i];
-        }
-
-        while (foo !== "bar") {
-          foo = "bar";
-        }
-
-        switch (foo) {
-        case "bar":
-          return "foo";
-        default:
-          return "bar";
-        }
-      }
-    `
+const options: {
+  [key: string]: {
+    allowDerived?: boolean;
+    allowedCalls?: string[];
+    allowedNews?: string[];
+    allowIIFE?: boolean;
+    commonjs?: boolean;
+  };
+} = {
+  allowDerived: {
+    allowDerived: true
   },
-  {
-    code: `
-      class ClassName { }
-      function functionName() { }
-      function* generatorName() { }
-
-      const leet = 1337;
-      const leetBig = 1337n;
-      const negative = -1;
-
-      const regularExpression = /bar/;
-
-      const str1 = 'bar';
-      const str2 = "bar";
-      const str3 = \`bar\`;
-
-      const identifier = bar;
-      const isArray = Array.isArray;
-
-      const f = function() { };
-      const g = () => 'bar';
-
-      const { o1, o2: o3 } = o;
-      const [ a1, a2 ] = a;
-    `
+  allowCallSymbol: {
+    allowedCalls: ['Symbol']
   },
-  {
-    code: `
-      import defaultExport1 from "module-name";
-      import * as all1 from "module-name";
-      import { export1, export2 } from "module-name";
-      import { export3 as alias1, export4 } from "module-name";
-      import { default as alias2, export5 } from "module-name";
-      import { "string name" as alias3 } from "module-name";
-      import defaultExport2, { export6 } from "module-name";
-      import defaultExport3, * as all2 from "module-name";
-      import "module-name";
-    `
+  allowCallBigInt: {
+    allowedCalls: ['BigInt']
   },
-  {
-    code: `
-      class ClassName { }
-      function functionName() { }
-      function* generatorName() { }
-
-      const leet = 1337;
-      const leetBig = 1337n;
-      const negative = -1;
-
-      const regularExpression = /bar/;
-
-      const str1 = 'bar';
-      const str2 = "bar";
-      const str3 = \`bar\`;
-
-      const identifier = bar;
-      const isArray = Array.isArray;
-
-      const f = function() { };
-      const g = () => 'bar';
-
-      const { o1, o2: o3 } = o;
-      const [ a1, a2 ] = a;
-
-      const name1 = 0, name2 = 0, name3 = 0;
-      export { name1, name2 as name2a, name3 as "name 3" };
-
-      export * from "module-name";
-      export * as name4 from "module-name";
-      export { name5, name6 } from "module-name";
-      export { import1 as name7, import2 as name8, name9 } from "module-name";
-      export { default as name10, name11 } from "module-name";
-    `
+  allowNoCalls: {
+    allowedCalls: []
   },
-  {
-    code: `
-      const x = 0;
-      export { x as default };
-    `
+  allowNewMapAndSet: {
+    allowedNews: ['Map', 'Set']
   },
-  {
-    code: `
-      export { default } from "module-name";
-    `
+  allowIIFE: {
+    allowIIFE: true
   },
-  {
-    code: `
-      export default class ClassName { }
-    `
+  commonjs: {
+    commonjs: true
   },
-  {
-    code: `
-      export default function f() { }
-    `
-  },
-  {
-    code: `
-      export default function* g() { }
-    `
-  },
-  {
-    code: `
-      export default class { }
-    `
-  },
-  {
-    code: `
-      export default function() { }
-    `
-  },
-  {
-    code: `
-      export default function* () { }
-    `
-  },
-  {
-    code: `
-      const symbol1 = Symbol();
-      export const symbol2 = Symbol();
-
-      const bigInt1 = BigInt(1);
-      export const bigInt2 = BigInt(2);
-    `
-  },
-  {
-    code: `
-      const symbol1 = Symbol();
-      export const symbol2 = Symbol();
-    `,
-    options: [
-      {
-        allowedCalls: ['Symbol']
-      }
-    ]
-  },
-  {
-    code: `
-      const bigInt1 = BigInt();
-      export const bigInt2 = BigInt();
-    `,
-    options: [
-      {
-        allowedCalls: ['BigInt']
-      }
-    ]
-  },
-  {
-    code: `
-      const map = new Map();
-      const set = new Set();
-    `,
-    options: [
-      {
-        allowedNews: ['Map', 'Set']
-      }
-    ]
-  },
-  {
-    code: `
-      (function() { return ''; })();
-      (() => { return ''; })();
-    `,
-    options: [
-      {
-        allowIIFE: true
-      }
-    ]
-  },
-  {
-    code: `
-      require('dotenv');
-      var fs = require('fs');
-      let cp = require('child_process');
-      const path = require('path');
-
-      module.exports = {};
-      module.exports.foobar = {};
-      exports = {};
-      exports.foobar = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ]
-  },
-  {
-    code: `
-      const b01 = a == b;
-      const b02 = a != b;
-      const b03 = a === b;
-      const b04 = a !== b;
-      const b05 = a < b;
-      const b06 = a <= b;
-      const b07 = a > b;
-      const b08 = a >= b;
-      const b09 = a << b;
-      const b10 = a >> b;
-      const b11 = a >>> b;
-      const b12 = a + b;
-      const b13 = a - b;
-      const b14 = a * b;
-      const b15 = a / b;
-      const b16 = a % b;
-      const b17 = a ** b;
-      const b18 = a | b;
-      const b19 = a ^ b;
-      const b20 = a & b;
-      const b21 = a in b;
-      const b22 = a instanceof b;
-
-      const l01 = a && b;
-      const l02 = a || b;
-      const l03 = a ?? b;
-
-      const u01 = -a;
-      const u02 = +a;
-      const u03 = !a;
-      const u04 = ~a;
-    `,
-    options: [
-      {
-        allowDerived: true
-      }
-    ]
+  noCommonjs: {
+    commonjs: false
   }
+};
+
+const valid: RuleTester.ValidTestCase[] = [
+  ...[
+    {
+      code: `
+        function foobar() {
+          do {
+            i++;
+          } while (i<10);
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+            s += i;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+            s += i;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          for (let i=0;i<10;i++) {
+            s += i;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          if (foo) {
+            bar();
+          }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          switch (foo) {
+          case 'bar':
+            break;
+          case 'baz':
+            break;
+          }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          throw new Error('Hello world!');
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          try { } catch (e) { }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          try { } catch (e) { } finally { }
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          while (i<10) {
+            i++;
+          }
+        }
+      `
+    }
+  ],
+  ...[
+    {
+      code: `class ClassName { }`
+    },
+    {
+      code: `function functionName() { }`
+    },
+    {
+      code: `function* generatorName() { }`
+    },
+    {
+      code: `const leet = 1337;`
+    },
+    {
+      code: `const leetBig = 1337n;`
+    },
+    {
+      code: `const negative = -1;`
+    },
+    {
+      code: `const regularExpression = /bar/;`
+    },
+    {
+      code: `const str1 = 'bar';`
+    },
+    {
+      code: `const str2 = "bar";`
+    },
+    {
+      code: `const str3 = \`bar\`;`
+    },
+    {
+      code: `const identifier = bar;`
+    },
+    {
+      code: `const isArray = Array.isArray;`
+    },
+    {
+      code: `const f = function() { };`
+    },
+    {
+      code: `const g = () => 'bar';`
+    },
+    {
+      code: `const { o1, o2: o3 } = o;`
+    },
+    {
+      code: `const [ a1, a2 ] = a;`
+    }
+  ],
+  ...[
+    {
+      code: `import defaultExport1 from "module-name";`
+    },
+    {
+      code: `import * as all1 from "module-name";`
+    },
+    {
+      code: `import { export1, export2 } from "module-name";`
+    },
+    {
+      code: `import { export3 as alias1, export4 } from "module-name";`
+    },
+    {
+      code: `import { default as alias2, export5 } from "module-name";`
+    },
+    {
+      code: `import { "string name" as alias3 } from "module-name";`
+    },
+    {
+      code: `import defaultExport2, { export6 } from "module-name";`
+    },
+    {
+      code: `import defaultExport3, * as all2 from "module-name";`
+    },
+    {
+      code: `import "module-name";`
+    }
+  ],
+  ...[
+    {
+      code: `class ClassName { }`
+    },
+    {
+      code: `function functionName() { }`
+    },
+    {
+      code: `function* generatorName() { }`
+    },
+    {
+      code: `const leet = 1337;`
+    },
+    {
+      code: `const leetBig = 1337n;`
+    },
+    {
+      code: `const negative = -1;`
+    },
+    {
+      code: `const regularExpression = /bar/;`
+    },
+    {
+      code: `const str1 = 'bar';`
+    },
+    {
+      code: `const str2 = "bar";`
+    },
+    {
+      code: `const str3 = \`bar\`;`
+    },
+    {
+      code: `const identifier = bar;`
+    },
+    {
+      code: `const isArray = Array.isArray;`
+    },
+    {
+      code: `const f = function() { };`
+    },
+    {
+      code: `const g = () => 'bar';`
+    },
+    {
+      code: `const { o1, o2: o3 } = o;`
+    },
+    {
+      code: `const [ a1, a2 ] = a;`
+    },
+    {
+      code: `
+        const name1 = 0, name2 = 0, name3 = 0;
+        export { name1, name2 as name2a, name3 as "name 3" };
+      `
+    },
+    {
+      code: `export * from "module-name";`
+    },
+    {
+      code: `export * as name4 from "module-name";`
+    },
+    {
+      code: `export { name1, name2 } from "module-name";`
+    },
+    {
+      code: `export { import1 as name1, import2 as name2, name3 } from "module-name";`
+    },
+    {
+      code: `export { default as name1, name2 } from "module-name";`
+    }
+  ],
+  ...[
+    {
+      code: `
+        const x = 0;
+        export { x as default };
+      `
+    },
+    {
+      code: `export { default } from "module-name";`
+    },
+    {
+      code: `export default class ClassName { }`
+    },
+    {
+      code: `export default function f() { }`
+    },
+    {
+      code: `export default function* g() { }`
+    },
+    {
+      code: `export default class { }`
+    },
+    {
+      code: `export default function() { }`
+    },
+    {
+      code: `export default function* () { }`
+    }
+  ],
+  ...[
+    {
+      code: `const symbol = Symbol();`
+    },
+    {
+      code: `export const symbol = Symbol();`
+    },
+    {
+      code: `const bigInt = BigInt(1);`
+    },
+    {
+      code: `export const bigInt = BigInt(1);`
+    }
+  ],
+  ...[
+    {
+      code: `const symbol = Symbol();`,
+      options: [options.allowCallSymbol]
+    },
+    {
+      code: `export const symbol = Symbol();`,
+      options: [options.allowCallSymbol]
+    }
+  ],
+  ...[
+    {
+      code: `const bigInt = BigInt();`,
+      options: [options.allowCallBigInt]
+    },
+    {
+      code: `export const bigInt = BigInt();`,
+      options: [options.allowCallBigInt]
+    }
+  ],
+  ...[
+    {
+      code: `const map = new Map();`,
+      options: [options.allowNewMapAndSet]
+    },
+    {
+      code: `const set = new Set();`,
+      options: [options.allowNewMapAndSet]
+    }
+  ],
+  ...[
+    {
+      code: `(function() { return ''; })();`,
+      options: [options.allowIIFE]
+    },
+    {
+      code: `(() => { return ''; })();`,
+      options: [options.allowIIFE]
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv');`,
+      options: [options.commonjs]
+    },
+    {
+      code: `var fs = require('fs');`,
+      options: [options.commonjs]
+    },
+    {
+      code: `let cp = require('child_process');`,
+      options: [options.commonjs]
+    },
+    {
+      code: `const path = require('path');`,
+      options: [options.commonjs]
+    },
+    {
+      code: `module.exports = {};`,
+      options: [options.commonjs]
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      options: [options.commonjs]
+    },
+    {
+      code: `exports = {};`,
+      options: [options.commonjs]
+    },
+    {
+      code: `exports.foobar = {};`,
+      options: [options.commonjs]
+    }
+  ],
+  ...[
+    {
+      code: `const b01 = a == b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b02 = a != b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b03 = a === b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b04 = a !== b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b05 = a < b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b06 = a <= b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b07 = a > b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b08 = a >= b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b09 = a << b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b10 = a >> b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b11 = a >>> b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b12 = a + b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b13 = a - b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b14 = a * b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b15 = a / b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b16 = a % b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b17 = a ** b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b18 = a | b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b19 = a ^ b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b20 = a & b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b21 = a in b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const b22 = a instanceof b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const l01 = a && b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const l02 = a || b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const l03 = a ?? b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const u01 = -a;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const u02 = +a;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const u03 = !a;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const u04 = ~a;`,
+      options: [options.allowDerived]
+    }
+  ]
 ];
 
 const invalid: RuleTester.InvalidTestCase[] = [
-  {
-    code: `
-      do {
-        i++;
-      } while (i<10);
-      for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-        s += i;
-      }
-      for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-        s += i;
-      }
-      for (let i=0;i<10;i++) {
-        s += i;
-      }
-      if (foo) {
-        bar();
-      }
-      switch (foo) {
-      case 'bar':
-        break;
-      case 'baz':
-        break;
-      }
-      throw new Error('Hello world!');
-      try { } catch (e) { }
-      try { } catch (e) { } finally { }
-      while (i<10) {
-        i++;
-      }
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 3,
-        endColumn: 22
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 7,
-        endLine: 6,
-        endColumn: 8
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 7,
-        endLine: 9,
-        endColumn: 8
-      },
-      {
-        messageId: '0',
-        line: 10,
-        column: 7,
-        endLine: 12,
-        endColumn: 8
-      },
-      {
-        messageId: '0',
-        line: 13,
-        column: 7,
-        endLine: 15,
-        endColumn: 8
-      },
-      {
-        messageId: '0',
-        line: 16,
-        column: 7,
-        endLine: 21,
-        endColumn: 8
-      },
-      {
-        messageId: '0',
-        line: 22,
-        column: 7,
-        endLine: 22,
-        endColumn: 39
-      },
-      {
-        messageId: '0',
-        line: 23,
-        column: 7,
-        endLine: 23,
-        endColumn: 28
-      },
-      {
-        messageId: '0',
-        line: 24,
-        column: 7,
-        endLine: 24,
-        endColumn: 40
-      },
-      {
-        messageId: '0',
-        line: 25,
-        column: 7,
-        endLine: 27,
-        endColumn: 8
-      }
-    ]
-  },
-  {
-    code: `
-      (function() { return ''; })();
-      (() => '')();
-
-      var v1 = (function() { })();
-      let v2 = (function() { })();
-      const v3 = (function() { })();
-      var v4 = (() => { })();
-      let v5 = (() => { })();
-      const v6 = (() => { })();
-
-      module.exports = (function() { })();
-      module.exports = (() => { })();
-
-      export const v7 = (function() { })();
-      export const v8 = (() => { })();
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 31
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 7,
-        endLine: 2,
-        endColumn: 20
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 16,
-        endLine: 4,
-        endColumn: 34
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 16,
-        endLine: 5,
-        endColumn: 34
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 18,
-        endLine: 6,
-        endColumn: 36
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 16,
-        endLine: 7,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 8,
-        column: 16,
-        endLine: 8,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 9,
-        column: 18,
-        endLine: 9,
-        endColumn: 31
-      },
-      {
-        messageId: '0',
-        line: 11,
-        column: 24,
-        endLine: 11,
-        endColumn: 42
-      },
-      {
-        messageId: '0',
-        line: 12,
-        column: 24,
-        endLine: 12,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 14,
-        column: 25,
-        endLine: 14,
-        endColumn: 43
-      },
-      {
-        messageId: '0',
-        line: 15,
-        column: 25,
-        endLine: 15,
-        endColumn: 38
-      }
-    ]
-  },
-  {
-    code: `
-      var v1 = (function() { })();
-      let v2 = (function() { })();
-      const v3 = (function() { })();
-      var v4 = (() => { })();
-      let v5 = (() => { })();
-      const v6 = (() => { })();
-
-      module.exports = (function() { })();
-      module.exports = (() => { })();
-
-      export const v7 = (function() { })();
-      export const v8 = (() => { })();
-    `,
-    options: [
-      {
-        allowIIFE: true,
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 10,
-        endLine: 1,
-        endColumn: 28
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 16,
-        endLine: 2,
-        endColumn: 34
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 18,
-        endLine: 3,
-        endColumn: 36
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 16,
-        endLine: 4,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 16,
-        endLine: 5,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 18,
-        endLine: 6,
-        endColumn: 31
-      },
-      {
-        messageId: '0',
-        line: 8,
-        column: 24,
-        endLine: 8,
-        endColumn: 42
-      },
-      {
-        messageId: '0',
-        line: 9,
-        column: 24,
-        endLine: 9,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 11,
-        column: 25,
-        endLine: 11,
-        endColumn: 43
-      },
-      {
-        messageId: '0',
-        line: 12,
-        column: 25,
-        endLine: 12,
-        endColumn: 38
-      }
-    ]
-  },
-  {
-    code: `
-      hello_world('hello world');
-
-      module.exports = hello_world('hello world');
-      export const hello = hello_world('hello world');
-      var foo1 = hello_world('bar1');
-      let foo2 = hello_world('bar2');
-      const foo3 = hello_world('bar3');
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 28
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 24,
-        endLine: 3,
-        endColumn: 50
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 28,
-        endLine: 4,
-        endColumn: 54
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 18,
-        endLine: 5,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 18,
-        endLine: 6,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 20,
-        endLine: 7,
-        endColumn: 39
-      }
-    ]
-  },
-  {
-    code: `
-      console.log('hello world');
-
-      module.exports = console.log('hello world');
-      export const hello = console.log('hello world');
-      var foo1 = console.log('bar1');
-      let foo2 = console.log('bar2');
-      const foo3 = console.log('bar3');
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 28
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 24,
-        endLine: 3,
-        endColumn: 50
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 28,
-        endLine: 4,
-        endColumn: 54
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 18,
-        endLine: 5,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 18,
-        endLine: 6,
-        endColumn: 37
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 20,
-        endLine: 7,
-        endColumn: 39
-      }
-    ]
-  },
-  {
-    code: `
-      new HelloWorld();
-
-      module.exports = new HelloWorld();
-      export const hello = new HelloWorld();
-      var foo1 = new Bar();
-      let foo2 = new Bar();
-      const foo3 = new Bar();
-    `,
-    options: [
-      {
-        allowedNews: ['Map', 'Set'],
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 18
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 24,
-        endLine: 3,
-        endColumn: 40
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 28,
-        endLine: 4,
-        endColumn: 44
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 18,
-        endLine: 5,
-        endColumn: 27
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 18,
-        endLine: 6,
-        endColumn: 27
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 20,
-        endLine: 7,
-        endColumn: 29
-      }
-    ]
-  },
-  {
-    code: `
-      fetch('/api').then(res=>res.text()).then(console.log);
-      await fetch('/api');
-      const promised = await fetch('/api');
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 55
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 7,
-        endLine: 2,
-        endColumn: 27
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 24,
-        endLine: 3,
-        endColumn: 43
-      }
-    ]
-  },
-  {
-    code: `
-      console.log('hello world');
-    `,
-    options: [
-      {
-        allowIIFE: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 28
-      }
-    ]
-  },
-  {
-    code: `
-      {
-        console.log('hello world');
-      }
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 2,
-        column: 9,
-        endLine: 2,
-        endColumn: 36
-      }
-    ]
-  },
-  {
-    code: `
-      const symbol1 = Symbol();
-      export const symbol2 = Symbol();
-
-      const bigInt1 = BigInt();
-      export const bigInt2 = BigInt();
-    `,
-    options: [
-      {
-        allowedCalls: []
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 17,
-        endLine: 1,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 30,
-        endLine: 2,
-        endColumn: 38
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 23,
-        endLine: 4,
-        endColumn: 31
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 30,
-        endLine: 5,
-        endColumn: 38
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = 1 + 2;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 18
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = x > 1 ? "a" : "b";
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 30
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = bar || baz;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 23
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = f\`bar\`;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 19
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = i++;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 16
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = -bar;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 17
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = \`\${bar}\`;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 21
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = bar?.baz;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 21
-      }
-    ]
-  },
-  {
-    code: `
-      module.exports = {};
-      module.exports.foobar = {};
-      exports = {};
-      exports.foobar = {};
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 21
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 7,
-        endLine: 2,
-        endColumn: 34
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 7,
-        endLine: 3,
-        endColumn: 20
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 7,
-        endLine: 4,
-        endColumn: 27
-      }
-    ]
-  },
-  {
-    code: `
-      require('dotenv');
-      var fs = require('fs');
-      let cp = require('child_process');
-      const path = require('path');
-
-      module.exports = {};
-      module.exports.foobar = {};
-      exports = {};
-      exports.foobar = {};
-    `,
-    options: [
-      {
-        commonjs: false
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 19
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 16,
-        endLine: 2,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 16,
-        endLine: 3,
-        endColumn: 40
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 20,
-        endLine: 4,
-        endColumn: 35
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 7,
-        endLine: 6,
-        endColumn: 27
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 7,
-        endLine: 7,
-        endColumn: 34
-      },
-      {
-        messageId: '0',
-        line: 8,
-        column: 7,
-        endLine: 8,
-        endColumn: 20
-      },
-      {
-        messageId: '0',
-        line: 9,
-        column: 7,
-        endLine: 9,
-        endColumn: 27
-      }
-    ]
-  },
-  {
-    code: `
-      notModule.exports = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      notExports = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 17
-      }
-    ]
-  },
-  {
-    code: `
-      notExports.foobar = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 24
-      }
-    ]
-  },
-  {
-    code: `
-      notModule.exports.foobar = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 31
-      }
-    ]
-  },
-  {
-    code: `
-      module.notExports.foobar = {};
-    `,
-    options: [
-      {
-        commonjs: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 31
-      }
-    ]
-  },
-  {
-    code: `
-      const b01 = a == b;
-      const b02 = a != b;
-      const b03 = a === b;
-      const b04 = a !== b;
-      const b05 = a < b;
-      const b06 = a <= b;
-      const b07 = a > b;
-      const b08 = a >= b;
-      const b09 = a << b;
-      const b10 = a >> b;
-      const b11 = a >>> b;
-      const b12 = a + b;
-      const b13 = a - b;
-      const b14 = a * b;
-      const b15 = a / b;
-      const b16 = a % b;
-      const b17 = a ** b;
-      const b18 = a | b;
-      const b19 = a ^ b;
-      const b20 = a & b;
-      const b21 = a in b;
-      const b22 = a instanceof b;
-
-      const l01 = a && b;
-      const l02 = a || b;
-      const l03 = a ?? b;
-
-      const u01 = -a;
-      const u02 = +a;
-      const u03 = !a;
-      const u04 = ~a;
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 13,
-        endLine: 1,
-        endColumn: 19
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 19,
-        endLine: 2,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 19,
-        endLine: 3,
-        endColumn: 26
-      },
-      {
-        messageId: '0',
-        line: 4,
-        column: 19,
-        endLine: 4,
-        endColumn: 26
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 19,
-        endLine: 5,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 19,
-        endLine: 6,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 19,
-        endLine: 7,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 8,
-        column: 19,
-        endLine: 8,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 9,
-        column: 19,
-        endLine: 9,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 10,
-        column: 19,
-        endLine: 10,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 11,
-        column: 19,
-        endLine: 11,
-        endColumn: 26
-      },
-      {
-        messageId: '0',
-        line: 12,
-        column: 19,
-        endLine: 12,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 13,
-        column: 19,
-        endLine: 13,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 14,
-        column: 19,
-        endLine: 14,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 15,
-        column: 19,
-        endLine: 15,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 16,
-        column: 19,
-        endLine: 16,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 17,
-        column: 19,
-        endLine: 17,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 18,
-        column: 19,
-        endLine: 18,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 19,
-        column: 19,
-        endLine: 19,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 20,
-        column: 19,
-        endLine: 20,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 21,
-        column: 19,
-        endLine: 21,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 22,
-        column: 19,
-        endLine: 22,
-        endColumn: 33
-      },
-      {
-        messageId: '0',
-        line: 24,
-        column: 19,
-        endLine: 24,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 25,
-        column: 19,
-        endLine: 25,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 26,
-        column: 19,
-        endLine: 26,
-        endColumn: 25
-      },
-
-      {
-        messageId: '0',
-        line: 28,
-        column: 19,
-        endLine: 28,
-        endColumn: 21
-      },
-      {
-        messageId: '0',
-        line: 29,
-        column: 19,
-        endLine: 29,
-        endColumn: 21
-      },
-      {
-        messageId: '0',
-        line: 30,
-        column: 19,
-        endLine: 30,
-        endColumn: 21
-      },
-      {
-        messageId: '0',
-        line: 31,
-        column: 19,
-        endLine: 31,
-        endColumn: 21
-      }
-    ]
-  },
-  {
-    code: `
-      const bLeft = f() + b;
-      const bRight = a - g();
-      const bBoth = f() * g();
-
-      const lLeft = f() && b;
-      const lRight = a || g();
-      const lBoth = f() ?? g();
-
-      const u = -f();
-    `,
-    options: [
-      {
-        allowDerived: true
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 15,
-        endLine: 1,
-        endColumn: 18
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 26,
-        endLine: 2,
-        endColumn: 29
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 21,
-        endLine: 3,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 3,
-        column: 27,
-        endLine: 3,
-        endColumn: 30
-      },
-      {
-        messageId: '0',
-        line: 5,
-        column: 21,
-        endLine: 5,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 6,
-        column: 27,
-        endLine: 6,
-        endColumn: 30
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 21,
-        endLine: 7,
-        endColumn: 24
-      },
-      {
-        messageId: '0',
-        line: 7,
-        column: 28,
-        endLine: 7,
-        endColumn: 31
-      },
-      {
-        messageId: '0',
-        line: 9,
-        column: 18,
-        endLine: 9,
-        endColumn: 21
-      }
-    ]
-  }
+  ...[
+    {
+      code: `
+        do {
+          i++;
+        } while (i<10);
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `
+        for (let i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+          s += i;
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        for (let i of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
+          s += i;
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        for (let i=0;i<10;i++) {
+          s += i;
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        if (foo) {
+          bar();
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        switch (foo) {
+        case 'bar':
+          break;
+        case 'baz':
+          break;
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 6,
+          endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        throw new Error('Hello world!');
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
+    },
+    {
+      code: `
+        try { } catch (e) { }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `
+        try { } catch (e) { } finally { }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `
+        while (i<10) {
+          i++;
+        }
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 3,
+          endColumn: 10
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `(function() { return ''; })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `(() => '')();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      code: `var x = (function() { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+    {
+      code: `let x = (function() { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+    {
+      code: `const x = (function() { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `var x = (() => { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `let x = (() => { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `const x = (() => { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `module.exports = (function() { })();`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      code: `module.exports = (() => { })();`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `export const x = (function() { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      code: `export const x = (() => { })();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `var x = (function() { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+    {
+      code: `let x = (function() { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+    {
+      code: `const x = (function() { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `var x = (() => { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `let x = (() => { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `const x = (() => { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `module.exports = (function() { })();`,
+      options: [
+        {
+          ...options.allowIIFE,
+          ...options.commonjs
+        }
+      ],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      code: `module.exports = (() => { })();`,
+      options: [
+        {
+          ...options.allowIIFE,
+          ...options.commonjs
+        }
+      ],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `export const x = (function() { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      code: `export const x = (() => { })();`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `hello_world('hello world');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `module.exports = hello_world('hello world');`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      code: `export const hello = hello_world('hello world');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 48
+        }
+      ]
+    },
+    {
+      code: `var foo = hello_world('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `let foo = hello_world('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `const foo = hello_world('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `console.log('hello world');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `module.exports = console.log('hello world');`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      code: `export const hello = console.log('hello world');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 48
+        }
+      ]
+    },
+    {
+      code: `var foo = console.log('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `let foo = console.log('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `const foo = console.log('bar');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `new HelloWorld();`,
+      options: [options.allowNewMapAndSet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `module.exports = new HelloWorld();`,
+      options: [
+        {
+          ...options.allowNewMapAndSet,
+          ...options.commonjs
+        }
+      ],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `export const hello = new HelloWorld();`,
+      options: [options.allowNewMapAndSet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      code: `var foo = new Bar();`,
+      options: [options.allowNewMapAndSet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `let foo = new Bar();`,
+      options: [options.allowNewMapAndSet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `const foo = new Bar();`,
+      options: [options.allowNewMapAndSet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `fetch('/api').then(res=>res.text()).then(console.log);`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 55
+        }
+      ]
+    },
+    {
+      code: `await fetch('/api');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `const promised = await fetch('/api');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `console.log('hello world');`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `{console.log('hello world');}`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const symbol = Symbol();`,
+      options: [options.allowNoCalls],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `export const symbol = Symbol();`,
+      options: [options.allowNoCalls],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `const bigInt = BigInt();`,
+      options: [options.allowNoCalls],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `export const bigInt = BigInt();`,
+      options: [options.allowNoCalls],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const foo = 1 + 2;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const foo = x > 1 ? "a" : "b";`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 30
+        }
+      ]
+    },
+    {
+      code: `const foo = bar || baz;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      code: `const foo = f\`bar\`;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const foo = i++;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 16
+        }
+      ]
+    },
+    {
+      code: `const foo = -bar;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: `const foo = \`\${bar}\`;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `const foo = bar?.baz;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `module.exports = {};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `exports = {};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      code: `exports.foobar = {};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv');`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `var fs = require('fs');`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      code: `let cp = require('child_process');`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `const path = require('path');`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `module.exports = {};`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `exports = {};`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      code: `exports.foobar = {};`,
+      options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `notModule.exports = {};`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `notExports = {};`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: `notExports.foobar = {};`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `notModule.exports.foobar = {};`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `module.notExports.foobar = {};`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const b01 = a == b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b02 = a != b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b03 = a === b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `const b04 = a !== b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `const b05 = a < b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b06 = a <= b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b07 = a > b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b08 = a >= b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b09 = a << b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b10 = a >> b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b11 = a >>> b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `const b12 = a + b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b13 = a - b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b14 = a * b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b15 = a / b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b16 = a % b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b17 = a ** b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b18 = a | b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b19 = a ^ b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b20 = a & b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const b21 = a in b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const b22 = a instanceof b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    },
+    {
+      code: `const l01 = a && b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const l02 = a || b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const l03 = a ?? b;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const u01 = -a;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `const u02 = +a;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `const u03 = !a;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `const u04 = ~a;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const bLeft = f() + b;`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const bRight = a - g();`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      code: `const bBoth = f() * g();`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 18
+        },
+        {
+          messageId: '0',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `const lLeft = f() && b;`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `const lRight = a || g();`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `const lBoth = f() ?? g();`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 18
+        },
+        {
+          messageId: '0',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    },
+    {
+      code: `const u = -f();`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    }
+  ]
 ];
 
 new RuleTester({

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -6,471 +6,604 @@ import {RuleTester} from 'eslint';
 import {trimTestCases} from './helpers';
 import {noTopLevelVariables} from '../../lib/rules/no-top-level-variables';
 
-const valid: RuleTester.ValidTestCase[] = [
-  {
-    code: `
-      function fVar() {
-        var foo = 'bar';
-      }
-      function fLet() {
-        let foo = 'bar';
-      }
-      function fConst() {
-        const foo = 'bar';
-      }
-    `
+const options: {
+  [key: string]: {
+    allowed?: string[];
+    kind?: string[];
+  };
+} = {
+  kindLet: {
+    kind: ['let']
   },
-  {
-    code: `
-      var path = require('path');
-      var foo1 = 'bar';
-      export var foo2 = 'bar';
-    `,
-    options: [
-      {
-        kind: ['var']
-      }
-    ]
+  kindNone: {
+    kind: []
   },
-  {
-    code: `
-      let path = require('path');
-      let foo1 = 'bar';
-      export let foo2 = 'bar';
-    `,
-    options: [
-      {
-        kind: ['let']
-      }
-    ]
+  kindVar: {
+    kind: ['var']
   },
-  {
-    code: `
-      class ClassName { }
-      function functionName() { }
-      function* generatorName() { }
-
-      const leet = 1337;
-      const leetBig = 1337n;
-      const negative = -1;
-
-      const regularExpression = /bar/;
-
-      const str1 = 'bar';
-      const str2 = "bar";
-      const str3 = \`bar\`;
-      const str4 = $\`bar\`;
-
-      const identifier = bar;
-      const isArray = Array.isArray;
-
-      const assignment = bar = 1;
-      const binary = bar + baz;
-      const logical = bar || baz;
-      const unary = -bar;
-      const update = i++;
-      const ternary = bar ? bar : baz;
-      const chain = foo?.bar;
-
-      const f = function() { };
-      const g = () => 'bar';
-
-      const { o1, o2: o3 } = o;
-      const [ a1, a2 ] = a;
-
-      const symbol = Symbol();
-      const bigInt = BigInt(1);
-
-      const path = require('path');
-      const promised = await h();
-    `
+  allowArray: {
+    allowed: ['ArrayExpression']
   },
-  {
-    code: `
-      export class ClassName { }
-      export function functionName() { }
-      export function* generatorName() { }
-
-      export const leet = 1337;
-      export const leetBig = 1337n;
-      export const negative = -1;
-
-      export const regularExpression = /bar/;
-
-      export const str1 = 'bar';
-      export const str2 = "bar";
-      export const str3 = \`bar\`;
-      export const str4 = $\`bar\`;
-
-      export const identifier = bar;
-      export const isArray = Array.isArray;
-
-      export const assignment = bar = 1;
-      export const binary = bar + baz;
-      export const logical = bar || baz;
-      export const unary = -bar;
-      export const update = i++;
-      export const ternary = bar ? bar : baz;
-      export const chain = foo?.bar;
-
-      export const f = function() { };
-      export const g = () => 'bar';
-
-      export const { o1, o2: o3 } = o;
-      export const [ a1, a2 ] = a;
-
-      export const symbol = Symbol();
-      export const bigInt = BigInt(1);
-
-      export const promised = await h();
-
-      const name1 = 0, name2 = 0, name3 = 0;
-      export { name1, name2 as name2a, name3 as "name 3" };
-
-      export * from "module-name";
-      export * as name4 from "module-name";
-      export { name5, name6 } from "module-name";
-      export { import1 as name7, import2 as name8, name9 } from "module-name";
-      export { default as name10, name11 } from "module-name";
-    `
-  },
-  {
-    code: `
-      const x = 0;
-      export { x as default };
-    `
-  },
-  {
-    code: `
-      export { default } from "module-name";
-    `
-  },
-  {
-    code: `
-      export default class ClassName { }
-    `
-  },
-  {
-    code: `
-      export default function f() { }
-    `
-  },
-  {
-    code: `
-      export default function* g() { }
-    `
-  },
-  {
-    code: `
-      export default class { }
-    `
-  },
-  {
-    code: `
-      export default function() { }
-    `
-  },
-  {
-    code: `
-      export default function* () { }
-    `
-  },
-  {
-    code: `
-      const foo = ["b", "a", "r"];
-    `,
-    options: [
-      {
-        allowed: ['ArrayExpression']
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = { bar: "baz" };
-    `,
-    options: [
-      {
-        allowed: ['ObjectExpression']
-      }
-    ]
+  allowObject: {
+    allowed: ['ObjectExpression']
   }
+};
+
+const valid: RuleTester.ValidTestCase[] = [
+  ...[
+    {
+      code: `
+        function fVar() {
+          var foo = 'bar';
+        }
+      `
+    },
+    {
+      code: `
+        function fLet() {
+          let foo = 'bar';
+        }
+      `
+    },
+    {
+      code: `
+        function fConst() {
+          const foo = 'bar';
+        }
+      `
+    }
+  ],
+  ...[
+    {
+      code: `
+        var path = require('path');
+        var foo1 = 'bar';
+        export var foo2 = 'bar';
+      `,
+      options: [options.kindVar]
+    },
+    {
+      code: `
+        let path = require('path');
+        let foo1 = 'bar';
+        export let foo2 = 'bar';
+      `,
+      options: [options.kindLet]
+    }
+  ],
+  ...[
+    {
+      code: `class ClassName { }`
+    },
+    {
+      code: `function functionName() { }`
+    },
+    {
+      code: `function* generatorName() { }`
+    },
+    {
+      code: `const leet = 1337;`
+    },
+    {
+      code: `const leetBig = 1337n;`
+    },
+    {
+      code: `const negative = -1;`
+    },
+    {
+      code: `const regularExpression = /bar/;`
+    },
+    {
+      code: `const str1 = 'bar';`
+    },
+    {
+      code: `const str2 = "bar";`
+    },
+    {
+      code: `const str3 = \`bar\`;`
+    },
+    {
+      code: `const str4 = $\`bar\`;`
+    },
+    {
+      code: `const identifier = bar;`
+    },
+    {
+      code: `const isArray = Array.isArray;`
+    },
+    {
+      code: `const assignment = bar = 1;`
+    },
+    {
+      code: `const binary = bar + baz;`
+    },
+    {
+      code: `const logical = bar || baz;`
+    },
+    {
+      code: `const unary = -bar;`
+    },
+    {
+      code: `const update = i++;`
+    },
+    {
+      code: `const ternary = bar ? bar : baz;`
+    },
+    {
+      code: `const chain = foo?.bar;`
+    },
+    {
+      code: `const f = function() { };`
+    },
+    {
+      code: `const g = () => 'bar';`
+    },
+    {
+      code: `const { o1, o2: o3 } = o;`
+    },
+    {
+      code: `const [ a1, a2 ] = a;`
+    },
+    {
+      code: `const symbol = Symbol();`
+    },
+    {
+      code: `const bigInt = BigInt(1);`
+    },
+    {
+      code: `const path = require('path');`
+    },
+    {
+      code: `const promised = await h();`
+    }
+  ],
+  ...[
+    {
+      code: `export class ClassName { }`
+    },
+    {
+      code: `export function functionName() { }`
+    },
+    {
+      code: `export function* generatorName() { }`
+    },
+    {
+      code: `export const leet = 1337;`
+    },
+    {
+      code: `export const leetBig = 1337n;`
+    },
+    {
+      code: `export const negative = -1;`
+    },
+    {
+      code: `export const regularExpression = /bar/;`
+    },
+    {
+      code: `export const str1 = 'bar';`
+    },
+    {
+      code: `export const str2 = "bar";`
+    },
+    {
+      code: `export const str3 = \`bar\`;`
+    },
+    {
+      code: `export const str4 = $\`bar\`;`
+    },
+    {
+      code: `export const identifier = bar;`
+    },
+    {
+      code: `export const isArray = Array.isArray;`
+    },
+    {
+      code: `export const assignment = bar = 1;`
+    },
+    {
+      code: `export const binary = bar + baz;`
+    },
+    {
+      code: `export const logical = bar || baz;`
+    },
+    {
+      code: `export const unary = -bar;`
+    },
+    {
+      code: `export const update = i++;`
+    },
+    {
+      code: `export const ternary = bar ? bar : baz;`
+    },
+    {
+      code: `export const chain = foo?.bar;`
+    },
+    {
+      code: `export const f = function() { };`
+    },
+    {
+      code: `export const g = () => 'bar';`
+    },
+    {
+      code: `export const { o1, o2: o3 } = o;`
+    },
+    {
+      code: `export const [ a1, a2 ] = a;`
+    },
+    {
+      code: `export const symbol = Symbol();`
+    },
+    {
+      code: `export const bigInt = BigInt(1);`
+    },
+    {
+      code: `export const promised = await h();`
+    },
+    {
+      code: `
+        const name1 = 0, name2 = 0, name3 = 0;
+        export { name1, name2 as name2a, name3 as "name 3" };
+      `
+    },
+    {
+      code: `export * from "module-name";`
+    },
+    {
+      code: `export * as name4 from "module-name";`
+    },
+    {
+      code: `export { name5, name6 } from "module-name";`
+    },
+    {
+      code: `export { import1 as name7, import2 as name8, name9 } from "module-name";`
+    },
+    {
+      code: `export { default as name10, name11 } from "module-name";`
+    },
+    {
+      code: `
+        const x = 0;
+        export { x as default };
+      `
+    },
+    {
+      code: `export { default } from "module-name";`
+    },
+    {
+      code: `export default class ClassName { }`
+    },
+    {
+      code: `export default function f() { }`
+    },
+    {
+      code: `export default function* g() { }`
+    },
+    {
+      code: `export default class { }`
+    },
+    {
+      code: `export default function() { }`
+    },
+    {
+      code: `export default function* () { }`
+    }
+  ],
+  ...[
+    {
+      code: `const foo = ["b", "a", "r"];`,
+      options: [options.allowArray]
+    },
+    {
+      code: `const foo = { bar: "baz" };`,
+      options: [options.allowObject]
+    }
+  ]
 ];
 
 const invalid: RuleTester.InvalidTestCase[] = [
-  {
-    code: `
-      var foo1 = 'bar';
-      let foo2 = 'bar';
-      const foo3 = 'bar';
-    `,
-    options: [
-      {
-        kind: []
-      }
-    ],
-    errors: [
-      {
-        messageId: '1',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 18
-      },
-      {
-        messageId: '2',
-        line: 2,
-        column: 7,
-        endLine: 2,
-        endColumn: 24
-      },
-      {
-        messageId: '3',
-        line: 3,
-        column: 7,
-        endLine: 3,
-        endColumn: 26
-      }
-    ]
-  },
-  {
-    code: `
-      {var foo1 = 'bar';}
-      {let foo2 = 'bar';}
-      {const foo3 = 'bar';}
-    `,
-    options: [
-      {
-        kind: []
-      }
-    ],
-    errors: [
-      {
-        messageId: '1',
-        line: 1,
-        column: 2,
-        endLine: 1,
-        endColumn: 19
-      },
-      {
-        messageId: '2',
-        line: 2,
-        column: 8,
-        endLine: 2,
-        endColumn: 25
-      },
-      {
-        messageId: '3',
-        line: 3,
-        column: 8,
-        endLine: 3,
-        endColumn: 27
-      }
-    ]
-  },
-  {
-    code: `
-      export var foo1 = 'bar';
-      export let foo2 = 'bar';
-      export const foo3 = 'bar';
-    `,
-    options: [
-      {
-        kind: []
-      }
-    ],
-    errors: [
-      {
-        messageId: '1',
-        line: 1,
-        column: 8,
-        endLine: 1,
-        endColumn: 25
-      },
-      {
-        messageId: '2',
-        line: 2,
-        column: 14,
-        endLine: 2,
-        endColumn: 31
-      },
-      {
-        messageId: '3',
-        line: 3,
-        column: 14,
-        endLine: 3,
-        endColumn: 33
-      }
-    ]
-  },
-  {
-    code: `
-      export var name1, name2;
-      export let name3, name4;
-    `,
-    errors: [
-      {
-        messageId: '1',
-        line: 1,
-        column: 8,
-        endLine: 1,
-        endColumn: 25
-      },
-      {
-        messageId: '2',
-        line: 2,
-        column: 14,
-        endLine: 2,
-        endColumn: 31
-      }
-    ]
-  },
-  {
-    code: `
-      var foo1 = 'bar', hello1 = 'world';
-      let foo2 = 'bar', hello2 = 'world';
-      const foo3 = 'bar', hello3 = 'world';
-    `,
-    options: [
-      {
-        kind: []
-      }
-    ],
-    errors: [
-      {
-        messageId: '1',
-        line: 1,
-        column: 1,
-        endLine: 1,
-        endColumn: 36
-      },
-      {
-        messageId: '2',
-        line: 2,
-        column: 7,
-        endLine: 2,
-        endColumn: 42
-      },
-      {
-        messageId: '3',
-        line: 3,
-        column: 7,
-        endLine: 3,
-        endColumn: 44
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = {bar: "baz"};
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 25
-      }
-    ]
-  },
-  {
-    code: `
-      const foo = {bar: "baz"}, hello = {world: "!"};
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 25
-      },
-      {
-        messageId: '0',
-        line: 1,
-        column: 27,
-        endLine: 1,
-        endColumn: 47
-      }
-    ]
-  },
-  {
-    code: `
-      const path = require('path'), foo1 = {};
-      const foo2 = {}, fs = require('fs');
-    `,
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 31,
-        endLine: 1,
-        endColumn: 40
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 13,
-        endLine: 2,
-        endColumn: 22
-      }
-    ]
-  },
-  {
-    code: `
-      const arr = [];
-      const foo = ["b", "a", "r"];
-    `,
-    options: [
-      {
-        allowed: ['ObjectExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 15
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 13,
-        endLine: 2,
-        endColumn: 34
-      }
-    ]
-  },
-  {
-    code: `
-      const obj = {};
-      const foo = { bar: "baz" };
-    `,
-    options: [
-      {
-        allowed: ['ArrayExpression']
-      }
-    ],
-    errors: [
-      {
-        messageId: '0',
-        line: 1,
-        column: 7,
-        endLine: 1,
-        endColumn: 15
-      },
-      {
-        messageId: '0',
-        line: 2,
-        column: 13,
-        endLine: 2,
-        endColumn: 33
-      }
-    ]
-  }
+  ...[
+    {
+      code: `var foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: `let foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '2',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
+      code: `const foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '3',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `{var foo = 'bar';}`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `{let foo = 'bar';}`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '2',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `{const foo = 'bar';}`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '3',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `export var foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `export let foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '2',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `export const foo = 'bar';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '3',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `export var name1, name2;`,
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    },
+    {
+      code: `export let name1, name2;`,
+      errors: [
+        {
+          messageId: '2',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `var foo = 'bar', hello = 'world';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `let foo = 'bar', hello = 'world';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '2',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `const foo = 'bar', hello = 'world';`,
+      options: [options.kindNone],
+      errors: [
+        {
+          messageId: '3',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 36
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const foo = {bar: "baz"};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
+    },
+    {
+      code: `const foo = {bar: "baz"}, hello = {world: "!"};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 25
+        },
+        {
+          messageId: '0',
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 47
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const path = require('path'), foo1 = {};`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 31,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      code: `const foo = {}, fs = require('fs');`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const arr = [];`,
+      options: [options.allowObject],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `const foo = ["b", "a", "r"];`,
+      options: [options.allowObject],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `const obj = {};`,
+      options: [options.allowArray],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `const foo = { bar: "baz" };`,
+      options: [options.allowArray],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
+    }
+  ]
 ];
 
 new RuleTester({


### PR DESCRIPTION
## Summary

Update the test suite such that there is only one case per test. To keep some sort of grouping that was there with the previous approach, related tests are grouped together in a sub-array.

This reverts some changes made in #761 and goes back to a style of testing that was used before that, going even further this time.

Besides that changes this also:
1. Abstracts the options away for improved readability within tests and also fewer changes if the options need to change.
2. Improve coverage in good weather test cases. Based on the bad weather test cases, the first set of good weather test cases now covers more control flow structures from the language.

## Progress

- [x] `no-top-level-side-effects`
- [x] `no-top-level-variables`

