### PR TITLE
Replace gitleaks by trufflehog

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -18,7 +18,16 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            actions-results-receiver-production.githubapp.com:443
+            api.github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -18,22 +18,12 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:443
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            objects.githubusercontent.com:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0
-      - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@cb7149a9b57195b609c63e8518d2c6056677d2d0 # v2.3.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_ENABLE_SUMMARY: true
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@612ff1a0f17ff9774bb680bac4b2fe012ecbc864 # v3.71.1
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
## Summary

Update the secret scanning workflow to replace gitleaks by trufflehog ([action docs](https://github.com/trufflesecurity/trufflehog#octocat-trufflehog-github-action)). This is just to try it and see how it works (and if it works better) and partly because the gitleaks action is facing some technical challenges that aren't being addressed.

The primary drawback I see for using trufflehog over gitleaks is that the action isn't really pinnable (it's a composable action that runs a Docker image). The VERSION input could be used to pin the container, but that wouldn't be supported by automation to auto-update. For this use case and this purpose I'd prefer staying up-to-date with latest automatically (and I'd just like to try trufflehog for an extended period of time).