### PR TITLE
Update egress policy for "Check / Test" job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -227,6 +227,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.codecov.io:443
             api.github.com:443
             artifactcache.actions.githubusercontent.com:443
             cli.codecov.io:443


### PR DESCRIPTION
Relates to #914

## Summary

Allow `api.codecov.io:443` for test job. Should address the warning currently emitted by the Codecov action:

> Test
> Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/c16abc29c95fcf9174b58eb7e1abf4c866893bc8/dist/codecov' failed with exit code 1
