### PR TITLE
Disallow calling `BigInt` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`38fe16e`) Disallow calling `BigInt` with the `no-top-level-side-effects`
+  rule by default.
 
 ## [3.1.0] - 2023-12-29
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -20,7 +20,7 @@ type Options = {
 };
 
 const allowedCallsOption = {
-  default: ['BigInt', 'Symbol']
+  default: ['Symbol']
 };
 const allowedNewsOption = {
   default: []

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -316,12 +316,6 @@ const valid: RuleTester.ValidTestCase[] = [
     },
     {
       code: `export const symbol = Symbol();`
-    },
-    {
-      code: `const bigInt = BigInt(1);`
-    },
-    {
-      code: `export const bigInt = BigInt(1);`
     }
   ],
   ...[
@@ -1266,6 +1260,32 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 2,
           endLine: 1,
           endColumn: 29
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `const bigInt = BigInt();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `export const bigInt = BigInt();`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 31
         }
       ]
     }


### PR DESCRIPTION
## Summary

Update the default configuration for `no-top-level-side-effects` to disallow calling `BigInt` by default. The reason for this is that, like other primitive constructors and the like, it is never necessary to use `BigInt` because you can write `12345n` (a number with the `n` suffix) to create a big int.