### PR TITLE
Add usage instructions for new ESLint config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`bfacef9`) Add usage documentation for new ESLint configuration syntax.
 
 ## [3.2.0] - 2024-04-12
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ npm install @ericcornelissen/eslint-plugin-top --save-dev
 
 ## Usage
 
+### New Config (since ESLint v9)
+
+Import from `@ericcornelissen/eslint-plugin-top` and use it as a plugin. Then
+configure the rules you want to use in the rules section:
+
+```javascript
+import top from '@ericcornelissen/eslint-plugin-top';
+
+export default [
+  {
+    plugins: {top},
+    rules: {
+      'top/no-top-level-side-effects': 'error',
+      'top/no-top-level-variables': 'error'
+    }
+  }
+];
+```
+
+Note that the rule prefix (`top` in the example) must match the name of the key
+used in the plugins object.
+
+### Legacy Config (before ESLint v9)
+
 First, add `@ericcornelissen/top` to the plugins section of your `.eslintrc`
 configuration file. You must omit the `eslint-plugin-` infix:
 


### PR DESCRIPTION
Closes #954
Relates to #941

## Summary

Update the [usage](https://github.com/ericcornelissen/eslint-plugin-top/tree/e5877f1fc3a216bf9718fa7d5b76be29efb4d557#usage) section of the `README.md` to include an explanation of how to set up usage with the new ESLint v9 configuration format. The old instructions are kept for now because ESLint v8 is still supported.