### PR TITLE
Correction for `no-top-level-side-effects` docs

### DIFF
--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -71,7 +71,7 @@ This rule accepts a configuration object with four options:
 
 - `allowedCalls` Configure what function calls are allowed at the top level. Can
   be any identifier. The default value covers standard JavaScript functions that
-  one might expect at the top level (such as `BigInt` and `Symbol`).
+  one might expect at the top level (such as `Symbol`).
 - `allowedNews` Configure what classes can be instantiated at the top level. Can
   be any identifier. By default no classes can be instantiated.
 - `allowIIFE: false` (default) Configure whether top level Immediately Invoked


### PR DESCRIPTION
Relates to #931

## Summary

The default configuration for `allowedCalls` no longer allows calling `BigInt`.