### PR TITLE
Add a recommended configuration (for ESLint v9 configurations)

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -3,7 +3,7 @@
   "check-coverage": true,
 
   "include": ["lib/"],
-  "exclude": ["lib/index.ts"],
+  "exclude": ["lib/configs", "lib/index.ts"],
 
   "branches": 100,
   "functions": 100,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`e81b7af`) Provide a recommended configuration.
 
 ## [3.2.1] - 2024-04-30
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,19 @@ npm install @ericcornelissen/eslint-plugin-top --save-dev
 
 ### New Config (since ESLint v9)
 
-Import from `@ericcornelissen/eslint-plugin-top` and use it as a plugin. Then
-configure the rules you want to use in the rules section:
+Import from `@ericcornelissen/eslint-plugin-top` and use it as a plugin or use
+the preset configuration, e.g.:
+
+```javascript
+import top from '@ericcornelissen/eslint-plugin-top';
+
+export default [
+  top.configs.recommended
+  // ...
+];
+```
+
+Or configure the rules you want to use in the rules section:
 
 ```javascript
 import top from '@ericcornelissen/eslint-plugin-top';

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -1,0 +1,24 @@
+import * as plugin from '../index';
+
+export const configRecommended = {
+  plugins: {top: plugin},
+  rules: {
+    'top/no-top-level-side-effects': [
+      'error',
+      {
+        allowedCalls: ['Symbol'],
+        allowedNews: ['Map', 'Set'],
+        allowIIFE: false,
+        allowDerived: false,
+        commonjs: true
+      }
+    ],
+    'top/no-top-level-variables': [
+      'error',
+      {
+        allowed: ['ArrayExpression', 'ObjectExpression'],
+        kind: ['const']
+      }
+    ]
+  }
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ISC
 
+import {configRecommended} from './configs/recommended';
 import {noTopLevelSideEffects} from './rules/no-top-level-side-effects';
 import {noTopLevelVariables} from './rules/no-top-level-variables';
 
@@ -13,4 +14,11 @@ import {noTopLevelVariables} from './rules/no-top-level-variables';
 export const rules = {
   'no-top-level-variables': noTopLevelVariables,
   'no-top-level-side-effects': noTopLevelSideEffects
+};
+
+/**
+ * @public
+ */
+export const configs = {
+  recommended: configRecommended
 };

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -4,7 +4,7 @@ module.exports = {
   coverageAnalysis: 'perTest',
   inPlace: false,
   ignoreStatic: true,
-  mutate: ['lib/**/*.ts', '!lib/index.ts'],
+  mutate: ['lib/**/*.ts', '!lib/index.ts', '!lib/configs/*.ts'],
 
   testRunner: 'mocha',
   mochaOptions: {


### PR DESCRIPTION
Closes #955

## Summary

Create and export a default configuration object to make adopting this plugin easier by omitting the configuration details.

It is only provided for ESLint v9/flat configurations. The motivation for this is that I'm only using flat configs, and this (seemingly) is preferred by ESLint going forward, hence I didn't backport it. If there's demand for a recommended config for pre-ESLint v9 configuration please open an issue.