### PR TITLE
Add a preset strict configuration (for ESLint v9 configurations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`be6a4af`) Provide a preset strict configuration.
 
 ## [3.2.2] - 2024-05-09
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ npm install @ericcornelissen/eslint-plugin-top --save-dev
 
 ### New Config (since ESLint v9)
 
-Import from `@ericcornelissen/eslint-plugin-top` and use it as a plugin or use
-the preset configuration, e.g.:
+Import from `@ericcornelissen/eslint-plugin-top` and use one of the preset
+configuration, e.g.:
 
 ```javascript
 import top from '@ericcornelissen/eslint-plugin-top';
 
 export default [
-  top.configs.recommended
+  top.configs.recommended,
+  // or
+  top.configs.strict
   // ...
 ];
 ```
 
-Or configure the rules you want to use in the rules section:
+Or configure the rules you want to use in the rules section, e.g.:
 
 ```javascript
 import top from '@ericcornelissen/eslint-plugin-top';

--- a/lib/configs/strict.ts
+++ b/lib/configs/strict.ts
@@ -1,0 +1,24 @@
+import * as plugin from '../index';
+
+export const configStrict = {
+  plugins: {top: plugin},
+  rules: {
+    'top/no-top-level-side-effects': [
+      'error',
+      {
+        allowedCalls: [],
+        allowedNews: [],
+        allowIIFE: false,
+        allowDerived: false,
+        commonjs: true
+      }
+    ],
+    'top/no-top-level-variables': [
+      'error',
+      {
+        allowed: [],
+        kind: ['const']
+      }
+    ]
+  }
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ISC
 
 import {configRecommended} from './configs/recommended';
+import {configStrict} from './configs/strict';
 import {noTopLevelSideEffects} from './rules/no-top-level-side-effects';
 import {noTopLevelVariables} from './rules/no-top-level-variables';
 
@@ -20,5 +21,6 @@ export const rules = {
  * @public
  */
 export const configs = {
-  recommended: configRecommended
+  recommended: configRecommended,
+  strict: configStrict
 };


### PR DESCRIPTION
Relates to #992

## Summary

Create and export a preset strict configuration object to make adopting this plugin to its full effect easier. The goal of this prest config is to disallow as much as possible. Like the recommended config, it does set `commonjs: true` for the `no-top-level-side-effects` rule to avoid having to mess with the configuration for CommonJS-based projects.