### PR TITLE
Add missing SPDX license headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # eslint-plugin-top
 
 Disallow side effects at the top level of files.

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ISC
+
 import * as plugin from '../index';
 
 export const configRecommended = {

--- a/lib/configs/strict.ts
+++ b/lib/configs/strict.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ISC
+
 import * as plugin from '../index';
 
 export const configStrict = {


### PR DESCRIPTION
Relates to #402, #674, #992, #994

## Summary

- Add missing SPDX license headers to new source code files.
- Add SPDX license headers to the README

  I believe it is now sufficiently different from the [original project](https://github.com/eramdam/eslint-plugin-top)'s README that it should be fine to declare the intended license for this file. 