### PR TITLE
Allow `"use strict';`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`a8f0bfd`) Allow `"strict mode";` for `no-top-level-side-effects` rule.
 
 ## [3.3.0] - 2024-05-09
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -242,6 +242,13 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
             return;
           }
 
+          if (
+            node.expression.type === 'Literal' &&
+            node.expression.value === 'use strict'
+          ) {
+            return;
+          }
+
           if (options.commonjs) {
             if (
               node.expression.type === 'CallExpression' &&

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -702,7 +702,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           endColumn: 10
         }
       ]
-    },
+    }
   ],
   ...[
     {

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -129,6 +129,24 @@ const valid: RuleTester.ValidTestCase[] = [
           }
         }
       `
+    },
+    {
+      code: `
+        "use strict";
+
+        function foobar() {
+          // Nothing to do
+        }
+      `
+    },
+    {
+      code: `
+        'use strict';
+
+        function foobar() {
+          // Nothing to do
+        }
+      `
     }
   ],
   ...[

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -688,7 +688,21 @@ const invalid: RuleTester.InvalidTestCase[] = [
           endColumn: 10
         }
       ]
-    }
+    },
+    {
+      code: `
+        "foobar";
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 10
+        }
+      ]
+    },
   ],
   ...[
     {


### PR DESCRIPTION
Closes #1067

## Summary

Update the `no-top-level-side-effects` rule to allow the use of `"use strict";`.