### PR TITLE
Use reusable workflows from current branch

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,4 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main
+    uses: ./.github/workflows/reusable-audit.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/eslint-plugin-top/.github/workflows/reusable-audit.yml@main
+    uses: ./.github/workflows/reusable-audit.yml
     with:
       refs: '["main", "v3"]'
   tooling:


### PR DESCRIPTION
## Summary

Always use reusable workflows from the current branch. Based on:
<https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow>