### PR TITLE
Automatically determine `commonjs` option value if unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`edac7cc`) Automatically determine if analysis should set `commonjs: true`
+  for the `no-top-level-side-effects` rule based on ESLint hints (if `commonjs`
+  is not explicitly configured).
 
 ## [3.3.1] - 2024-07-10
 

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -67,7 +67,7 @@ module.exports = function () {
 
 ### Options
 
-This rule accepts a configuration object with four options:
+This rule accepts a configuration object with five options:
 
 - `allowedCalls` Configure what function calls are allowed at the top level. Can
   be any identifier. The default value covers standard JavaScript functions that
@@ -79,9 +79,10 @@ This rule accepts a configuration object with four options:
 - `allowDerived: false` (default) Configure whether derivations - binary,
   logical, or unary operations on values and variables - are allowed at the top
   level.
-- `commonjs: false` (default) Configure whether the code being analyzed is, or
-  is partially, CommonJS code. Allows the use `require`, `module.exports` and
-  `exports` at the top level.
+- `commonjs` Configure whether the code being analyzed is, or is partially,
+  CommonJS code. If not specified it will use ESLint hints to determine if a
+  given piece of code is written in CommonJS or not. For CommonJS it allows for
+  the use of `require`, `module.exports`, and `exports` at the top level.
 
 #### `allowedCalls`
 

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -2,11 +2,11 @@
 
 import type {Rule} from 'eslint';
 
-export function isInESModule(node: Rule.Node) {
+export function IsCommonJs(node: Rule.Node) {
   while (node.type !== 'Program') {
     node = node.parent;
   }
-  return node.sourceType === 'module';
+  return node.sourceType === 'script';
 }
 
 export function isTopLevel(node: Rule.Node) {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -2,6 +2,13 @@
 
 import type {Rule} from 'eslint';
 
+export function isInESModule(node: Rule.Node) {
+  while (node.type !== 'Program') {
+    node = node.parent;
+  }
+  return node.sourceType === 'module';
+}
+
 export function isTopLevel(node: Rule.Node) {
   let scope = node.parent;
   while (scope.type === 'BlockStatement') {

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -9,7 +9,7 @@ import type {
   VariableDeclaration
 } from 'estree';
 
-import {isInESModule, isTopLevel} from '../helpers';
+import {IsCommonJs, isTopLevel} from '../helpers';
 
 type Options = {
   readonly allowedCalls: ReadonlyArray<string>;
@@ -237,7 +237,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
       allowDerived: provided?.allowDerived || false,
       commonjs: provided?.commonjs,
       isCommonjs: (node) =>
-        options.commonjs === undefined ? !isInESModule(node) : options.commonjs
+        options.commonjs === undefined ? IsCommonJs(node) : options.commonjs
     };
 
     return {

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ISC
 
+import type {Linter} from 'eslint';
+
 import * as parser from '@typescript-eslint/parser';
 import {RuleTester} from 'eslint';
 
@@ -38,6 +40,17 @@ const options: {
   },
   noCommonjs: {
     commonjs: false
+  }
+};
+
+const parserOptions: {
+  [key: string]: Linter.ParserOptions;
+} = {
+  sourceTypeModule: {
+    sourceType: 'module'
+  },
+  sourceTypeScript: {
+    sourceType: 'script'
   }
 };
 
@@ -408,6 +421,82 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `exports.foobar = {};`,
       options: [options.commonjs]
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv'); // non-module autodetect`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `var fs = require('fs');`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `let cp = require('child_process');`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `const path = require('path');`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `module.exports = {};`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `exports = {};`,
+      parserOptions: parserOptions.sourceTypeScript
+    },
+    {
+      code: `exports.foobar = {};`,
+      parserOptions: parserOptions.sourceTypeScript
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv'); // module autodetect w/ commonjs: true`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `var fs = require('fs');`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `let cp = require('child_process');`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `const path = require('path');`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `module.exports = {};`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `exports = {};`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
+    },
+    {
+      code: `exports.foobar = {};`,
+      options: [options.commonjs],
+      parserOptions: parserOptions.sourceTypeModule
     }
   ],
   ...[
@@ -1619,6 +1708,226 @@ const invalid: RuleTester.InvalidTestCase[] = [
     {
       code: `exports.foobar = {};`,
       options: [options.noCommonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv'); // module autodetect`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `var fs = require('fs');`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      code: `let cp = require('child_process');`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `const path = require('path');`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `module.exports = {};`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `exports = {};`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      code: `exports.foobar = {};`,
+      parserOptions: parserOptions.sourceTypeModule,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    }
+  ],
+  ...[
+    {
+      code: `require('dotenv'); // non-module autodetect w/ commonjs: false`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `var fs = require('fs');`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      code: `let cp = require('child_process');`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `const path = require('path');`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `module.exports = {};`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `module.exports.foobar = {};`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `exports = {};`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      code: `exports.foobar = {};`,
+      options: [options.noCommonjs],
+      parserOptions: parserOptions.sourceTypeScript,
       errors: [
         {
           messageId: '0',


### PR DESCRIPTION
Closes #1070

## Summary

Update the implementation of the `no-top-level-side-effects` rule to determine if the given node is from a CJS or ESM piece of code by looking at the `sourceType` of the root `Program` node.

This functionality is only enabled when the `commonjs` option is not specified. If it is specified it always takes precedence.