### PR TITLE
bug: check object properties for top level side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning].
 
 ## [Unreleased]
 
+- (`f878f23`) Make the `no-top-level-side-effects` report side effects inside
+  top-level objects.
+- (`9f32d1d`) Make the `no-top-level-side-effects` report derived object values
+  when `allowDerived: false` (i.e. `{[foo]:42}` and `{...foo}`).
 - (`f878f23`) Allow literals at the top level.
 - (`edac7cc`) Automatically determine if analysis should set `commonjs: true`
   for the `no-top-level-side-effects` rule based on ESLint hints (if `commonjs`

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: ISC
 
-import type { Rule } from 'eslint';
+import type {Rule} from 'eslint';
 
 const topLevelTypes = new Set([
   'ArrayExpression',
@@ -13,6 +13,8 @@ const topLevelTypes = new Set([
   'LogicalExpression',
   'NewExpression',
   'ObjectExpression',
+  'Property',
+  'SpreadElement',
   'UnaryExpression',
   'VariableDeclaration',
   'VariableDeclarator'

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: ISC
 
-import type {Rule} from 'eslint';
+import type { Rule } from 'eslint';
 
 const topLevelTypes = new Set([
   'ArrayExpression',

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: ISC
 
-import type { Rule } from 'eslint';
-import type { CallExpression, NewExpression, AssignmentExpression, Expression } from 'estree';
+import type {Rule} from 'eslint';
+import type {CallExpression, NewExpression, AssignmentExpression} from 'estree';
 
-import { IsCommonJs, isTopLevel } from '../helpers';
+import {IsCommonJs, isTopLevel} from '../helpers';
 
 type Options = {
   readonly allowedCalls: ReadonlyArray<string>;
@@ -74,83 +74,6 @@ function isNew(expression: NewExpression, name: string): boolean {
   return (
     expression.callee.type === 'Identifier' && expression.callee.name === name
   );
-}
-
-function checkExpression(
-  context: Rule.RuleContext,
-  options: Options,
-  node: Rule.Node,
-  expression: Expression
-) {
-  const report = () => {
-    context.report({
-      node: expression,
-      messageId: disallowedSideEffect.id
-    });
-  };
-
-  switch (expression.type) {
-    case 'AwaitExpression':
-    case 'ChainExpression':
-    case 'ConditionalExpression':
-    case 'TaggedTemplateExpression':
-    case 'UpdateExpression':
-      report();
-      break;
-
-    case 'BinaryExpression':
-    case 'LogicalExpression':
-      if (options.allowDerived) {
-        checkExpression(context, options, node, expression.left);
-        checkExpression(context, options, node, expression.right);
-        return;
-      }
-
-      report();
-      break;
-
-    case 'CallExpression':
-      if (options.isCommonjs(node) && isCallTo(expression, 'require')) {
-        return;
-      }
-
-      if (options.allowedCalls.some((name) => isCallTo(expression, name))) {
-        return;
-      }
-
-      report();
-      break;
-    case 'NewExpression':
-      if (options.allowedNews.some((name) => isNew(expression, name))) {
-        return;
-      }
-
-      report();
-      break;
-
-    case 'TemplateLiteral':
-      if (expression.expressions.length === 0) {
-        return;
-      }
-
-      report();
-      break;
-
-    case 'UnaryExpression':
-      if (expression.argument.type === 'Literal') {
-        return;
-      }
-
-      if (options.allowDerived) {
-        checkExpression(context, options, node, expression.argument);
-        return;
-      }
-
-      report();
-      break;
-
-    default:
-  }
 }
 
 export const noTopLevelSideEffects: Rule.RuleModule = {
@@ -253,7 +176,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
         if (
           options.allowIIFE &&
           isIIFE(node) &&
-          node.parent.type === 'ExpressionStatement'
+          ['ExpressionStatement', 'Property'].includes(node.parent.type)
         ) {
           return;
         }
@@ -418,28 +341,6 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           context.report({
             node,
             messageId: disallowedSideEffect.id
-          });
-        }
-      },
-      ObjectExpression: (node) => {
-        if (isTopLevel(node)) {
-          node.properties.forEach(property => {
-            if (property.type === 'SpreadElement') {
-              checkExpression(context, options, node, property.argument);
-              return;
-            }
-
-            switch (property.value.type) {
-              case 'Identifier':
-              case 'ObjectPattern':
-              case 'ArrayPattern':
-              case 'RestElement':
-              case 'AssignmentPattern':
-              case 'MemberExpression':
-                return;
-              default:
-                checkExpression(context, options, node, property.value);
-            }
           });
         }
       },

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -269,19 +269,21 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
         }
       },
       Property: (node) => {
-        if (isTopLevel(node)) {
-          if (node.computed) {
-            if (options.allowDerived) return;
+        if (options.allowDerived || !node.computed) {
+          return;
+        }
 
-            context.report({
-              node: node.key,
-              messageId: disallowedSideEffect.id
-            });
-          }
+        if (isTopLevel(node)) {
+          context.report({
+            node: node.key,
+            messageId: disallowedSideEffect.id
+          });
         }
       },
       SpreadElement: (node) => {
-        if (options.allowDerived) return;
+        if (options.allowDerived) {
+          return;
+        }
 
         if (isTopLevel(node)) {
           context.report({

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -176,7 +176,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
         if (
           options.allowIIFE &&
           isIIFE(node) &&
-          ['ExpressionStatement', 'Property'].includes(node.parent.type)
+          node.parent.type === 'ExpressionStatement'
         ) {
           return;
         }

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -23,7 +23,7 @@ const allowedNewsOption = {
 
 const disallowedSideEffect = {
   id: '0',
-  message: 'Side effects at the top level are not allowed',
+  message: 'Side effects at the top level are not allowed'
 };
 
 function isCallTo(expression: CallExpression, name: string): boolean {
@@ -268,6 +268,28 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           });
         }
       },
+      Property: (node) => {
+        if (isTopLevel(node)) {
+          if (node.computed) {
+            if (options.allowDerived) return;
+
+            context.report({
+              node: node.key,
+              messageId: disallowedSideEffect.id
+            });
+          }
+        }
+      },
+      SpreadElement: (node) => {
+        if (options.allowDerived) return;
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
       SwitchStatement: (node) => {
         if (isTopLevel(node)) {
           context.report({
@@ -343,7 +365,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
             messageId: disallowedSideEffect.id
           });
         }
-      },
+      }
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "_eslint": "eslint --report-unused-disable-directives",
-    "_prettier": "prettier ./**/*.{js,json,jsonc,md,ts,yml} --ignore-path .gitignore",
+    "_prettier": "prettier \"**/*.{js,json,jsonc,md,ts,yml}\" --ignore-path .gitignore",
     "audit": "better-npm-audit audit",
     "audit:runtime": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.js",

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -656,18 +656,10 @@ const valid: RuleTester.ValidTestCase[] = [
   ],
   ...[
     {
-      code: `const x = { foo: ok() };`,
-      options: [{allowedCalls: ['ok']}]
-    },
-    {
       code: `const x = {};`
     },
     {
       code: `const x = { foo: 123 };`
-    },
-    {
-      code: `const x = { foo: 123 + 345 };`,
-      options: [options.allowDerived]
     },
     {
       code: `const x = { foo: 123, bar: 'baz' };`
@@ -676,35 +668,32 @@ const valid: RuleTester.ValidTestCase[] = [
       code: `const x = { foo: () => 123 };`
     },
     {
-      code: `const x = { foo: require('./config') };`,
-      options: [options.commonjs]
+      code: `const x = { foo: function() { return true; } };`
     },
     {
-      code: `const x = { foo: function*() { yield true } };`
+      code: `const x = { foo: function*() { yield true; } };`
     },
     {
-      code: `const x = { foo() { return 123 } };`
+      code: `const x = { foo() { return 123; } };`
     },
     {
-      code: `const x = { ...ok() };`,
-      options: [{allowedCalls: ['ok'], ...options.allowDerived}]
-    },
-    {
-      code: `const x = { ...foo };`,
-      options: [options.allowDerived]
-    },
-    {
-      code: `const x = () => ({ foo: ok() });`
-    },
-    {
-      code: `const x = () => ({ ...ok() });`
+      code: `const x = { foo: ok() };`,
+      options: [{allowedCalls: ['ok']}]
     },
     {
       code: `const x = { foo: new Foo() };`,
       options: [{allowedNews: ['Foo']}]
     },
     {
+      code: `const x = { foo: require('./config') };`,
+      options: [options.commonjs]
+    },
+    {
       code: `const x = { foo: 40 + 2 };`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const x = { ...foo };`,
       options: [options.allowDerived]
     },
     {
@@ -712,14 +701,30 @@ const valid: RuleTester.ValidTestCase[] = [
       options: [options.allowDerived]
     },
     {
-      code: `const x = function() { return { [foo]: true }; };`
+      code: `const x = { ...ok() };`,
+      options: [{...options.allowDerived, allowedCalls: ['ok']}]
     },
     {
-      code: `const x = { [foo()]: true };`,
-      options: [{allowedCalls: ['foo'], ...options.allowDerived}]
+      code: `const x = { [ok()]: true };`,
+      options: [{...options.allowDerived, allowedCalls: ['ok']}]
     },
     {
-      code: `const x = function() { return { [foo()]: true }; };`
+      code: `const f = () => ({ foo: 3 + 14 });`
+    },
+    {
+      code: `const f = () => ({ foo: bar() });`
+    },
+    {
+      code: `const f = () => ({ ...foo });`
+    },
+    {
+      code: `const f = () => ({ ...bar() });`
+    },
+    {
+      code: `const f = () => ({ [foo]: true });`
+    },
+    {
+      code: `const f = () => ({ [bar()]: true });`
     }
   ]
 ];
@@ -2571,7 +2576,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
   ...[
     {
       code: `const x = { foo: bad() };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2584,7 +2588,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: { nested: { bar: bad() } } };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2597,7 +2600,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: bad(), bar: worse(), baz: worst() };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2650,7 +2652,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: new Foo() };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2663,7 +2664,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: (function(){ return 1 })() };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2676,7 +2676,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: 40 + 2 };`,
-      options: [],
       errors: [
         {
           messageId: '0',
@@ -2689,7 +2688,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: await bar() };`,
-      options: [],
       errors: [
         {
           messageId: '0',

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -660,8 +660,44 @@ const valid: RuleTester.ValidTestCase[] = [
       options: [{ allowedCalls: ['ok'] }],
     },
     {
+      code: `const x = {};`,
+      options: [],
+    },
+    {
+      code: `const x = { foo: 123 };`,
+      options: [],
+    },
+    {
+      code: `const x = { foo: 123, bar: 'baz' };`,
+      options: [],
+    },
+    {
+      code: `const x = { foo: () => 123 };`,
+      options: [],
+    },
+    {
+      code: `const x = { foo: require('./config') };`,
+      options: [options.commonjs],
+    },
+    {
+      code: `const x = { foo: (function(){ return 1 })() };`,
+      options: [options.allowIIFE]
+    },
+    {
+      code: `const x = { foo: function*() { yield true } };`,
+      options: [],
+    },
+    {
+      code: `const x = { foo() { return 123 } };`,
+      options: [],
+    },
+    {
       code: `const x = { ...ok() };`,
       options: [{ allowedCalls: ['ok'] }],
+    },
+    {
+      code: `const x = { ...foo };`,
+      options: [],
     },
     {
       code: `const x = () => ({ foo: ok() });`,
@@ -674,7 +710,15 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `const x = { foo: new Foo() };`,
       options: [{ allowedNews: ['Foo'] }],
-    }
+    },
+    {
+      code: `const x = { foo: 40 + 2 };`,
+      options: [options.allowDerived],
+    },
+    {
+      code: `const x = { [foo]: true };`,
+      options: [],
+    },
   ]
 ];
 
@@ -2614,7 +2658,72 @@ const invalid: RuleTester.InvalidTestCase[] = [
           endColumn: 27
         }
       ]
-    }
+    },
+    {
+      code: `const x = { foo: (function(){ return 1 })() };`,
+      options: [],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      code: `const x = { foo: 40 + 2 };`,
+      options: [],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `const x = { foo: await bar() };`,
+      options: [],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `module.exports = { foo: { bar: bad() } };`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 32,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      code: `const x = { [foo()]: true };`,
+      options: [],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
   ],
 ];
 

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -2718,6 +2718,30 @@ const invalid: RuleTester.InvalidTestCase[] = [
       ]
     },
     {
+      code: `const x = { ...foo };`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const x = { [foo]: true };`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 17
+        }
+      ]
+    },
+    {
       code: `const x = { [foo()]: true };`,
       options: [options.allowDerived],
       errors: [

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -680,10 +680,6 @@ const valid: RuleTester.ValidTestCase[] = [
       options: [options.commonjs]
     },
     {
-      code: `const x = { foo: (function(){ return 1 })() };`,
-      options: [options.allowIIFE]
-    },
-    {
       code: `const x = { foo: function*() { yield true } };`
     },
     {
@@ -2751,6 +2747,19 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 14,
           endLine: 1,
           endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const x = { foo: (function(){ return 1 })() };`,
+      options: [options.allowIIFE],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 44
         }
       ]
     }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ISC
 
-import type { Linter } from 'eslint';
+import type {Linter} from 'eslint';
 
 import * as parser from '@typescript-eslint/parser';
-import { RuleTester } from 'eslint';
+import {RuleTester} from 'eslint';
 
-import { trimTestCases } from './helpers';
-import { noTopLevelSideEffects } from '../../lib/rules/no-top-level-side-effects';
+import {trimTestCases} from './helpers';
+import {noTopLevelSideEffects} from '../../lib/rules/no-top-level-side-effects';
 
 const options: {
   [key: string]: {

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -657,68 +657,74 @@ const valid: RuleTester.ValidTestCase[] = [
   ...[
     {
       code: `const x = { foo: ok() };`,
-      options: [{ allowedCalls: ['ok'] }],
+      options: [{allowedCalls: ['ok']}]
     },
     {
-      code: `const x = {};`,
-      options: [],
+      code: `const x = {};`
     },
     {
-      code: `const x = { foo: 123 };`,
-      options: [],
+      code: `const x = { foo: 123 };`
     },
     {
-      code: `const x = { foo: 123, bar: 'baz' };`,
-      options: [],
+      code: `const x = { foo: 123 + 345 };`,
+      options: [options.allowDerived]
     },
     {
-      code: `const x = { foo: () => 123 };`,
-      options: [],
+      code: `const x = { foo: 123, bar: 'baz' };`
+    },
+    {
+      code: `const x = { foo: () => 123 };`
     },
     {
       code: `const x = { foo: require('./config') };`,
-      options: [options.commonjs],
+      options: [options.commonjs]
     },
     {
       code: `const x = { foo: (function(){ return 1 })() };`,
       options: [options.allowIIFE]
     },
     {
-      code: `const x = { foo: function*() { yield true } };`,
-      options: [],
+      code: `const x = { foo: function*() { yield true } };`
     },
     {
-      code: `const x = { foo() { return 123 } };`,
-      options: [],
+      code: `const x = { foo() { return 123 } };`
     },
     {
       code: `const x = { ...ok() };`,
-      options: [{ allowedCalls: ['ok'] }],
+      options: [{allowedCalls: ['ok'], ...options.allowDerived}]
     },
     {
       code: `const x = { ...foo };`,
-      options: [],
+      options: [options.allowDerived]
     },
     {
-      code: `const x = () => ({ foo: ok() });`,
-      options: [],
+      code: `const x = () => ({ foo: ok() });`
     },
     {
-      code: `const x = () => ({ ...ok() });`,
-      options: [],
+      code: `const x = () => ({ ...ok() });`
     },
     {
       code: `const x = { foo: new Foo() };`,
-      options: [{ allowedNews: ['Foo'] }],
+      options: [{allowedNews: ['Foo']}]
     },
     {
       code: `const x = { foo: 40 + 2 };`,
-      options: [options.allowDerived],
+      options: [options.allowDerived]
     },
     {
       code: `const x = { [foo]: true };`,
-      options: [],
+      options: [options.allowDerived]
     },
+    {
+      code: `const x = function() { return { [foo]: true }; };`
+    },
+    {
+      code: `const x = { [foo()]: true };`,
+      options: [{allowedCalls: ['foo'], ...options.allowDerived}]
+    },
+    {
+      code: `const x = function() { return { [foo()]: true }; };`
+    }
   ]
 ];
 
@@ -2622,7 +2628,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { foo: ok(), bar: fine(), baz: notThis() };`,
-      options: [{ allowedCalls: ['ok', 'fine'] }],
+      options: [{allowedCalls: ['ok', 'fine']}],
       errors: [
         {
           messageId: '0',
@@ -2635,7 +2641,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { ...bad() };`,
-      options: [],
+      options: [options.allowDerived],
       errors: [
         {
           messageId: '0',
@@ -2713,7 +2719,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
     },
     {
       code: `const x = { [foo()]: true };`,
-      options: [],
+      options: [options.allowDerived],
       errors: [
         {
           messageId: '0',
@@ -2723,8 +2729,8 @@ const invalid: RuleTester.InvalidTestCase[] = [
           endColumn: 19
         }
       ]
-    },
-  ],
+    }
+  ]
 ];
 
 new RuleTester({
@@ -2735,5 +2741,5 @@ new RuleTester({
   }
 }).run('no-top-level-side-effects', noTopLevelSideEffects, {
   valid: valid.map(trimTestCases),
-  invalid: invalid.map(trimTestCases),
+  invalid: invalid.map(trimTestCases)
 });

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: ISC
 
 import * as parser from '@typescript-eslint/parser';
-import { RuleTester } from 'eslint';
+import {RuleTester} from 'eslint';
 
-import { trimTestCases } from './helpers';
-import { noTopLevelVariables } from '../../lib/rules/no-top-level-variables';
+import {trimTestCases} from './helpers';
+import {noTopLevelVariables} from '../../lib/rules/no-top-level-variables';
 
 const options: {
   [key: string]: {

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: ISC
 
 import * as parser from '@typescript-eslint/parser';
-import {RuleTester} from 'eslint';
+import { RuleTester } from 'eslint';
 
-import {trimTestCases} from './helpers';
-import {noTopLevelVariables} from '../../lib/rules/no-top-level-variables';
+import { trimTestCases } from './helpers';
+import { noTopLevelVariables } from '../../lib/rules/no-top-level-variables';
 
 const options: {
   [key: string]: {


### PR DESCRIPTION
Hi 

I took a quick stab at this issue: https://github.com/ericcornelissen/eslint-plugin-top/issues/1080 
These changes only check Objects - array/string templates are still not checked. 

I'm not sure if I understand the design in the existing code, so I'm just trying to follow as close as I could. Question though - why don't we simply check call expression, and recursively check if it's happening at the top level? 

for example - if we change `isTopLevel` to something like this:

```ts
function isTopLevel(node: Rule.Node) {
  let scope = node.parent;
  while (scope && [
    'BlockStatement',
    'Property',
    'ObjectExpression',
    'VariableDeclarator',
    'VariableDeclaration',
    'ExportNamedDeclaration',
    'ExportDefaultDeclaration',
    'ExpressionStatement'
  ].includes(scope.type)) {
    scope = scope.parent;
  }
  return scope && scope.type === 'Program' && 
         !['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']
           .includes(scope.parent?.type);
}
```

then we can simply evaluate CallExpressions only - 

```ts
create: context => {
  return {
    CallExpression:  node => {
      if (isTopLevel(node)) reportIfNotAllowed();
    },
  }
}
```

did I get this right 🤨