### PR TITLE
Rewrite how we determine if a node is at the top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`f878f23`) Allow literals at the top level.
 - (`edac7cc`) Automatically determine if analysis should set `commonjs: true`
   for the `no-top-level-side-effects` rule based on ESLint hints (if `commonjs`
   is not explicitly configured).

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -2,6 +2,22 @@
 
 import type {Rule} from 'eslint';
 
+const topLevelTypes = new Set([
+  'ArrayExpression',
+  'AssignmentExpression',
+  'BinaryExpression',
+  'BlockStatement',
+  'CallExpression',
+  'ExportNamedDeclaration',
+  'ExpressionStatement',
+  'LogicalExpression',
+  'NewExpression',
+  'ObjectExpression',
+  'UnaryExpression',
+  'VariableDeclaration',
+  'VariableDeclarator'
+]);
+
 export function IsCommonJs(node: Rule.Node) {
   while (node.type !== 'Program') {
     node = node.parent;
@@ -11,7 +27,7 @@ export function IsCommonJs(node: Rule.Node) {
 
 export function isTopLevel(node: Rule.Node) {
   let scope = node.parent;
-  while (scope.type === 'BlockStatement') {
+  while (topLevelTypes.has(scope.type)) {
     scope = scope.parent;
   }
   return scope.type === 'Program';

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: ISC
 
 import type {Rule} from 'eslint';
-import type {
-  CallExpression,
-  ExpressionStatement,
-  Expression,
-  NewExpression,
-  VariableDeclaration
-} from 'estree';
+import type {CallExpression, NewExpression, AssignmentExpression} from 'estree';
 
 import {IsCommonJs, isTopLevel} from '../helpers';
 
@@ -32,66 +26,47 @@ const disallowedSideEffect = {
   message: 'Side effects at the top level are not allowed'
 };
 
-function ifTopLevelReportWith(context: Rule.RuleContext) {
-  return (node: Rule.Node) => {
-    if (isTopLevel(node)) {
-      context.report({
-        node,
-        messageId: disallowedSideEffect.id
-      });
-    }
-  };
-}
-
 function isCallTo(expression: CallExpression, name: string): boolean {
   return (
     expression.callee.type === 'Identifier' && expression.callee.name === name
   );
 }
 
-function isExportsAssignment(node: ExpressionStatement): boolean {
+function isExportsAssignment(node: AssignmentExpression): boolean {
+  return node.left.type === 'Identifier' && node.left.name === 'exports';
+}
+
+function isExportPropertyAssignment(node: AssignmentExpression): boolean {
   return (
-    node.expression.type === 'AssignmentExpression' &&
-    node.expression.left.type === 'Identifier' &&
-    node.expression.left.name === 'exports'
+    node.left.type === 'MemberExpression' &&
+    node.left.object.type === 'Identifier' &&
+    node.left.object.name === 'exports'
   );
 }
 
-function isExportPropertyAssignment(node: ExpressionStatement): boolean {
+function isIIFE(node: CallExpression): boolean {
   return (
-    node.expression.type === 'AssignmentExpression' &&
-    node.expression.left.type === 'MemberExpression' &&
-    node.expression.left.object.type === 'Identifier' &&
-    node.expression.left.object.name === 'exports'
+    node.callee.type === 'ArrowFunctionExpression' ||
+    node.callee.type === 'FunctionExpression'
   );
 }
 
-function isIIFE(node: ExpressionStatement): boolean {
+function isModuleAssignment(node: AssignmentExpression): boolean {
   return (
-    node.expression.type === 'CallExpression' &&
-    (node.expression.callee.type === 'ArrowFunctionExpression' ||
-      node.expression.callee.type === 'FunctionExpression')
+    node.left.type === 'MemberExpression' &&
+    node.left.object.type === 'Identifier' &&
+    node.left.object.name === 'module'
   );
 }
 
-function isModuleAssignment(node: ExpressionStatement): boolean {
+function isModulePropertyAssignment(node: AssignmentExpression): boolean {
   return (
-    node.expression.type === 'AssignmentExpression' &&
-    node.expression.left.type === 'MemberExpression' &&
-    node.expression.left.object.type === 'Identifier' &&
-    node.expression.left.object.name === 'module'
-  );
-}
-
-function isModulePropertyAssignment(node: ExpressionStatement): boolean {
-  return (
-    node.expression.type === 'AssignmentExpression' &&
-    node.expression.left.type === 'MemberExpression' &&
-    node.expression.left.object.type === 'MemberExpression' &&
-    node.expression.left.object.object.type === 'Identifier' &&
-    node.expression.left.object.object.name === 'module' &&
-    node.expression.left.object.property.type === 'Identifier' &&
-    node.expression.left.object.property.name === 'exports'
+    node.left.type === 'MemberExpression' &&
+    node.left.object.type === 'MemberExpression' &&
+    node.left.object.object.type === 'Identifier' &&
+    node.left.object.object.name === 'module' &&
+    node.left.object.property.type === 'Identifier' &&
+    node.left.object.property.name === 'exports'
   );
 }
 
@@ -99,96 +74,6 @@ function isNew(expression: NewExpression, name: string): boolean {
   return (
     expression.callee.type === 'Identifier' && expression.callee.name === name
   );
-}
-
-function checkExpression(
-  context: Rule.RuleContext,
-  options: Options,
-  node: Rule.Node,
-  expression: Expression
-) {
-  const report = () => {
-    context.report({
-      node: expression,
-      messageId: disallowedSideEffect.id
-    });
-  };
-
-  switch (expression.type) {
-    case 'AwaitExpression':
-    case 'ChainExpression':
-    case 'ConditionalExpression':
-    case 'TaggedTemplateExpression':
-    case 'UpdateExpression':
-      report();
-      break;
-
-    case 'BinaryExpression':
-    case 'LogicalExpression':
-      if (options.allowDerived) {
-        checkExpression(context, options, node, expression.left);
-        checkExpression(context, options, node, expression.right);
-        return;
-      }
-
-      report();
-      break;
-
-    case 'CallExpression':
-      if (options.isCommonjs(node) && isCallTo(expression, 'require')) {
-        return;
-      }
-
-      if (options.allowedCalls.some((name) => isCallTo(expression, name))) {
-        return;
-      }
-
-      report();
-      break;
-    case 'NewExpression':
-      if (options.allowedNews.some((name) => isNew(expression, name))) {
-        return;
-      }
-
-      report();
-      break;
-
-    case 'TemplateLiteral':
-      if (expression.expressions.length === 0) {
-        return;
-      }
-
-      report();
-      break;
-
-    case 'UnaryExpression':
-      if (expression.argument.type === 'Literal') {
-        return;
-      }
-
-      if (options.allowDerived) {
-        checkExpression(context, options, node, expression.argument);
-        return;
-      }
-
-      report();
-      break;
-
-    default:
-  }
-}
-
-function checkVariableDeclaration(
-  context: Rule.RuleContext,
-  options: Options,
-  node: Rule.Node,
-  declaration: VariableDeclaration
-) {
-  for (const {init} of declaration.declarations) {
-    if (init !== null && init !== undefined) {
-      checkExpression(context, options, node, init);
-    }
-  }
 }
 
 export const noTopLevelSideEffects: Rule.RuleModule = {
@@ -241,64 +126,224 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
     };
 
     return {
-      ExpressionStatement: (node) => {
+      AssignmentExpression: (node) => {
+        if (
+          options.isCommonjs(node) &&
+          (isExportsAssignment(node) ||
+            isExportPropertyAssignment(node) ||
+            isModuleAssignment(node) ||
+            isModulePropertyAssignment(node))
+        ) {
+          return;
+        }
+
         if (isTopLevel(node)) {
-          if (options.allowIIFE && isIIFE(node)) {
-            return;
-          }
-
-          if (
-            node.expression.type === 'Literal' &&
-            node.expression.value === 'use strict'
-          ) {
-            return;
-          }
-
-          if (options.isCommonjs(node)) {
-            if (
-              node.expression.type === 'CallExpression' &&
-              isCallTo(node.expression, 'require')
-            ) {
-              return;
-            } else if (
-              node.expression.type === 'AssignmentExpression' &&
-              (isExportsAssignment(node) ||
-                isExportPropertyAssignment(node) ||
-                isModuleAssignment(node) ||
-                isModulePropertyAssignment(node))
-            ) {
-              checkExpression(context, options, node, node.expression.right);
-              return;
-            }
-          }
-
+          context.report({
+            node: node.parent,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      AwaitExpression: (node) => {
+        if (isTopLevel(node)) {
           context.report({
             node,
             messageId: disallowedSideEffect.id
           });
         }
       },
-
-      ExportNamedDeclaration: (node) => {
-        if (node.declaration?.type === 'VariableDeclaration') {
-          checkVariableDeclaration(context, options, node, node.declaration);
+      BinaryExpression: (node) => {
+        if (options.allowDerived) {
+          return;
         }
-      },
-      VariableDeclaration: (node) => {
+
         if (isTopLevel(node)) {
-          checkVariableDeclaration(context, options, node, node);
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
         }
       },
+      CallExpression: (node) => {
+        if (options.isCommonjs(node) && isCallTo(node, 'require')) {
+          return;
+        }
 
-      DoWhileStatement: ifTopLevelReportWith(context),
-      ForInStatement: ifTopLevelReportWith(context),
-      ForOfStatement: ifTopLevelReportWith(context),
-      ForStatement: ifTopLevelReportWith(context),
-      IfStatement: ifTopLevelReportWith(context),
-      SwitchStatement: ifTopLevelReportWith(context),
-      ThrowStatement: ifTopLevelReportWith(context),
-      TryStatement: ifTopLevelReportWith(context),
-      WhileStatement: ifTopLevelReportWith(context)
+        if (options.allowedCalls.some((name) => isCallTo(node, name))) {
+          return;
+        }
+
+        if (
+          options.allowIIFE &&
+          isIIFE(node) &&
+          node.parent.type === 'ExpressionStatement'
+        ) {
+          return;
+        }
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ChainExpression: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ConditionalExpression: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      DoWhileStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ForInStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ForOfStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ForStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      IfStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      LogicalExpression: (node) => {
+        if (options.allowDerived) {
+          return;
+        }
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      NewExpression: (node) => {
+        if (options.allowedNews.some((name) => isNew(node, name))) {
+          return;
+        }
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      SwitchStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      TaggedTemplateExpression: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      TemplateLiteral: (node) => {
+        if (node.expressions.length === 0) {
+          return;
+        }
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      ThrowStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      TryStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      UnaryExpression: (node) => {
+        if (node.argument.type === 'Literal') {
+          return;
+        }
+
+        if (options.allowDerived) {
+          return;
+        }
+
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      UpdateExpression: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      WhileStatement: (node) => {
+        if (isTopLevel(node)) {
+          context.report({
+            node,
+            messageId: disallowedSideEffect.id
+          });
+        }
+      }
     };
   }
 };

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -146,11 +146,6 @@ export const noTopLevelVariables: Rule.RuleModule = {
     };
 
     return {
-      ExportNamedDeclaration: (node) => {
-        if (node.declaration?.type === 'VariableDeclaration') {
-          checkVariableDeclaration(context, options, node.declaration);
-        }
-      },
       VariableDeclaration: (node) => {
         if (isTopLevel(node)) {
           checkVariableDeclaration(context, options, node);

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -145,6 +145,20 @@ const valid: RuleTester.ValidTestCase[] = [
     },
     {
       code: `
+        function foobar() {
+          const binaryExpression0 = 1 + 2;
+          const logicalExpression0 = true || false;
+          const string0 = 'foobar';
+          const string1 = "foobar";
+          const string2 = \`foobar\`;
+          const string3 = \`foo\${bar}\`;
+          const unaryExpression0 = -1;
+          const unaryExpression1 = -binaryExpression;
+        }
+      `
+    },
+    {
+      code: `
         "use strict";
 
         function foobar() {
@@ -155,6 +169,24 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `
         'use strict';
+
+        function foobar() {
+          // Nothing to do
+        }
+      `
+    },
+    {
+      code: `
+        "foobar";
+
+        function foobar() {
+          // Nothing to do
+        }
+      `
+    },
+    {
+      code: `
+        42;
 
         function foobar() {
           // Nothing to do
@@ -777,20 +809,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
           endColumn: 10
         }
       ]
-    },
-    {
-      code: `
-        "foobar";
-      `,
-      errors: [
-        {
-          messageId: '0',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 10
-        }
-      ]
     }
   ],
   ...[
@@ -802,7 +820,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 31
+          endColumn: 30
         }
       ]
     },
@@ -814,7 +832,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 14
+          endColumn: 13
         }
       ]
     },
@@ -1092,7 +1110,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 28
+          endColumn: 27
         }
       ]
     },
@@ -1167,7 +1185,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 28
+          endColumn: 27
         }
       ]
     },
@@ -1243,7 +1261,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 18
+          endColumn: 17
         }
       ]
     },
@@ -1327,7 +1345,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 55
+          endColumn: 54
         }
       ]
     },
@@ -1339,7 +1357,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 21
+          endColumn: 20
         }
       ]
     },
@@ -1366,7 +1384,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 28
+          endColumn: 27
         }
       ]
     }
@@ -1380,7 +1398,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 2,
           endLine: 1,
-          endColumn: 29
+          endColumn: 28
         }
       ]
     }
@@ -1623,7 +1641,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 19
+          endColumn: 18
         }
       ]
     },
@@ -1729,7 +1747,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 19
+          endColumn: 18
         }
       ]
     },
@@ -1836,7 +1854,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 19
+          endColumn: 18
         }
       ]
     },

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -94,9 +94,11 @@ const valid: RuleTester.ValidTestCase[] = [
     },
     {
       code: `
-        function foobar() {
+        async function foobar() {
           if (foo) {
             bar();
+          } else {
+            await baz();
           }
         }
       `
@@ -148,12 +150,15 @@ const valid: RuleTester.ValidTestCase[] = [
         function foobar() {
           const binaryExpression0 = 1 + 2;
           const logicalExpression0 = true || false;
+          const conditionalExpression0 = foo ? bar : baz;
           const string0 = 'foobar';
           const string1 = "foobar";
           const string2 = \`foobar\`;
           const string3 = \`foo\${bar}\`;
+          const string4 = $\`foobar\`;
           const unaryExpression0 = -1;
           const unaryExpression1 = -binaryExpression;
+          const chainExpression0 = foo?.bar;
         }
       `
     },
@@ -807,6 +812,20 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 1,
           endLine: 3,
           endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        const taggedTemplateString = $\`foobar\`;
+      `,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 30,
+          endLine: 1,
+          endColumn: 39
         }
       ]
     }


### PR DESCRIPTION
Closes #1072
Relates to #1088

## Summary

Update the `isTopLevel` to consider more statements and expression to be part of the top level, similar to `BlockStatement`, so that expression are "automatically" considered top-level if they appear in said expressions or statements. This change was [suggested](https://github.com/ericcornelissen/eslint-plugin-top/pull/1088#issue-2421599336) by @pallymore who deserves full credit for this idea, I merely did the engineering work of refactoring to code.

Apart from resolving #1072, this _should_ not change too much how the plugin behaves (except for some minor changes to the ranges of reported errors). The only thing that should have changes, if at all, is more accurate reports of top-level side effects (e.g. inside an object).