### PR TITLE
Use auto-detect for CommonJS in configuration presets

### DIFF
--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -11,8 +11,7 @@ export const configRecommended = {
         allowedCalls: ['Symbol'],
         allowedNews: ['Map', 'Set'],
         allowIIFE: false,
-        allowDerived: false,
-        commonjs: true
+        allowDerived: false
       }
     ],
     'top/no-top-level-variables': [

--- a/lib/configs/strict.ts
+++ b/lib/configs/strict.ts
@@ -11,8 +11,7 @@ export const configStrict = {
         allowedCalls: [],
         allowedNews: [],
         allowIIFE: false,
-        allowDerived: false,
-        commonjs: true
+        allowDerived: false
       }
     ],
     'top/no-top-level-variables': [


### PR DESCRIPTION
Relates to #992, #994, #1070, and #1081

## Summary

Simplify and improve the configuration presets by relying on the auto-detect CommonJS feature instead of setting the `commonjs` option to true explicitly.