### PR TITLE
Allow three more expression in `no-top-level-variables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`aaa56b7`) Always allow for `ImportExpression`, `SequenceExpression`, and
+  `ThisExpression` for `no-top-level-variables`.
 
 ## [3.4.0] - 2024-07-29
 

--- a/docs/rules/no-top-level-variables.md
+++ b/docs/rules/no-top-level-variables.md
@@ -78,13 +78,6 @@ Examples of **correct** code when `'ObjectExpression'` is in the list:
 const hello = {world: '!'};
 ```
 
-Additionally, all others expression types that aren't always allowed can be
-allowed, those are:
-
-- `ImportExpression` (e.g. `import('path');`)
-- `SequenceExpression` (e.g. `(3, 14);`)
-- `ThisExpression` (e.g. `this;`)
-
 #### `kind`
 
 Examples of **correct** code when `'const'` is in the list:

--- a/lib/rules/no-top-level-variables.ts
+++ b/lib/rules/no-top-level-variables.ts
@@ -30,11 +30,14 @@ const allowedOption = {
     'ConditionalExpression',
     'FunctionExpression',
     'Identifier',
+    'ImportExpression',
     'Literal',
     'LogicalExpression',
     'MemberExpression',
+    'SequenceExpression',
     'TaggedTemplateExpression',
     'TemplateLiteral',
+    'ThisExpression',
     'UnaryExpression',
     'UpdateExpression'
   ]

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -349,15 +349,33 @@ const valid: RuleTester.ValidTestCase[] = [
   // Configurable allowed declarations
   ...[
     {
-      code: `const foo = import('path');`,
+      code: `const foo = import('path');`
+    },
+    {
+      code: `const foo = (3, 5);`
+    },
+    {
+      code: `const foo = this;`
+    },
+    {
+      code: `
+        // Validate that 'ImportExpression' is not rejected as an allowed expression type
+        const foo = import('path');
+      `,
       options: [{allowed: ['ImportExpression']}]
     },
     {
-      code: `const foo = (3, 5);`,
+      code: `
+        // Validate that 'SequenceExpression' is not rejected as an allowed expression type
+        const foo = (3, 5);
+      `,
       options: [{allowed: ['SequenceExpression']}]
     },
     {
-      code: `const foo = this;`,
+      code: `
+        // Validate that 'ThisExpression' is not rejected as an allowed expression type
+        const foo = this;
+      `,
       options: [{allowed: ['ThisExpression']}]
     },
     {
@@ -678,46 +696,6 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 7,
           endLine: 1,
           endColumn: 27
-        }
-      ]
-    }
-  ],
-
-  // Configurable allowed declarations
-  ...[
-    {
-      code: `const foo = import('path');`,
-      errors: [
-        {
-          messageId: '0',
-          line: 1,
-          column: 7,
-          endLine: 1,
-          endColumn: 27
-        }
-      ]
-    },
-    {
-      code: `const foo = (3, 5);`,
-      errors: [
-        {
-          messageId: '0',
-          line: 1,
-          column: 7,
-          endLine: 1,
-          endColumn: 19
-        }
-      ]
-    },
-    {
-      code: `const foo = this;`,
-      errors: [
-        {
-          messageId: '0',
-          line: 1,
-          column: 7,
-          endLine: 1,
-          endColumn: 17
         }
       ]
     }


### PR DESCRIPTION
Closes #1119
Relates to #1107

## Summary

Update the `no-top-level-variables` rule to always allow the expressions `ImportExpression`, `SequenceExpression`, and `ThisExpression` in top level variables. This has been reflected in the implementation, tests, and documentation.

These expression types are still included in the enum for optionally allowed expressions so as to not break existing configurations that allow them (otherwise ESLint would complain about unknown values). The tests have also been updated to be explicit about this.