### PR TITLE
Correct auditing commands in CI

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -70,5 +70,5 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Audit all npm dependencies
+      - name: Audit for vulnerabilities
         run: npm run audit:vulnerabilities

--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Audit all npm dependencies
-        run: npm run audit:vulnerabilities:runtime
+        run: npm run audit:vulnerabilities

--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -35,5 +35,5 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Audit production npm dependencies
-        run: npm run audit:vulnerabilities:runtime
+      - name: Audit for vulnerabilities
+        run: npm run audit:runtime


### PR DESCRIPTION
Relates to #1247, [Audit (release) 113](https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/11676909316), [Audit (release) 114](https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/11696569036)

## Summary

It was updated to use the new command for auditing runtime dependencies even though the latest release does not yet use this command. This should be updated with the next release.

Also correct the vulnerability auditing command used in the dev workflow to audit all dependencies, not just runtime dependencies, as it was [before](https://github.com/ericcornelissen/eslint-plugin-top/pull/1247/files#diff-955cef0410c99c817e51f67fb6a2181894468bf7a53d5027fd399ddc02f38efbL74).