### PR TITLE
Set up ODGen SAST scan in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -291,6 +291,23 @@ jobs:
         run: npm clean-install
       - name: Lint the manifest
         run: npm run check:manifest
+  odgen:
+    name: ODGen
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Perform ODGen analysis
+        uses: ericcornelissen/odgen-action@f471a1a56ea6eebdf91ab37874f128385c877f91 # v1.0.1
+        with:
+          vulnerability_type: proto_pollution
   reproducible:
     name: Reproducible build
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Relates to #313

## Summary

Add a new CI job that runs the SAST tool [ODGen](https://github.com/Song-Li/ODGen) using the [odgen-action](https://github.com/ericcornelissen/odgen-action).