### PR TITLE
Try out `eslint-plugin-depend`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,11 @@
 // Check out ESLint at: https://eslint.org/
 
-import tsparser from '@typescript-eslint/parser';
-import tseslint from '@typescript-eslint/eslint-plugin';
+import depend from 'eslint-plugin-depend';
 import eslintPlugin from 'eslint-plugin-eslint-plugin';
 import json from '@eslint/json';
 import markdown from '@eslint/markdown';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
 import yml from 'eslint-plugin-yml';
 
 export default [
@@ -23,7 +24,7 @@ export default [
   {
     name: 'TypeScript Code',
     files: ['lib/**/*.ts'],
-    plugins: {tseslint},
+    plugins: {depend, tseslint},
     languageOptions: {
       parserOptions: {
         project: './tsconfig.json',
@@ -31,6 +32,7 @@ export default [
       }
     },
     rules: {
+      'depend/ban-dependencies': 'error',
       'tseslint/consistent-return': 'error',
       'tseslint/consistent-type-exports': 'error',
       'tseslint/consistent-type-imports': 'error',
@@ -92,8 +94,9 @@ export default [
   {
     name: 'Tests',
     files: ['tests/**/*'],
-    plugins: {tseslint},
+    plugins: {depend, tseslint},
     rules: {
+      'depend/ban-dependencies': 'error',
       'tseslint/no-unused-vars': 'error'
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "@ericcornelissen/eslint-plugin-top",
       "version": "3.4.0",
-      "dev": true,
       "license": "ISC",
       "devDependencies": {
         "@ericcornelissen/eslint-plugin-top": "file:./",
@@ -27,6 +26,7 @@
         "c8": "10.1.1",
         "depreman": "0.3.2",
         "eslint": "9.15.0",
+        "eslint-plugin-depend": "0.12.0",
         "eslint-plugin-eslint-plugin": "6.3.2",
         "eslint-plugin-yml": "1.16.0",
         "eslint-v8": "npm:eslint@8.0.1",
@@ -4511,6 +4511,18 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-plugin-depend": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-0.12.0.tgz",
+      "integrity": "sha512-bS5ESnC3eXDJPNv0RKkzRbLO45hRRLR/dleAUdbysXChWz1bAxa4MRh14EtDREn7fZieueqz4L7TfQQbzvdYHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^1.2.0",
+        "module-replacements": "^2.1.0",
+        "semver": "^7.6.3"
+      }
+    },
     "node_modules/eslint-plugin-eslint-plugin": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-6.3.2.tgz",
@@ -5377,6 +5389,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-1.2.0.tgz",
+      "integrity": "sha512-45LSPmWf+gC5tdCQMNH4s9Sr00bIkiD9aN7dc5hqkrEw1geRYyDQS1v1oMHAW3ysfxfndqGsrDREHHjNNbKUfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^3.0.1"
       }
     },
     "node_modules/fetch-node-website": {
@@ -8572,6 +8594,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-replacements": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.6.0.tgz",
+      "integrity": "sha512-LL+VhVXMIie3aO/uqPPAGaP7fhJb6yr98FW5IcSSJv+0gmJvS2c/L3C8WIaAA/HPyVhabKFKBKcfeLLi7WnRvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/move-file": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "c8": "10.1.1",
     "depreman": "0.3.2",
     "eslint": "9.15.0",
+    "eslint-plugin-depend": "0.12.0",
     "eslint-plugin-eslint-plugin": "6.3.2",
     "eslint-plugin-yml": "1.16.0",
     "eslint-v8": "npm:eslint@8.0.1",


### PR DESCRIPTION
## Summary

Add `eslint-plugin-depend` as a dependency and use it with ESLint to suggest alternatives to various dependencies with the goal of preventing dependency tree bloat.

As of this commit the plugin does not detect any problems, but the idea is that it would prevent problems from being introduced later OR being detected as the plugin is updated.