### PR TITLE
Disallow shadowing `require` in CommonJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning].
 - (`aaa56b7`) Always allow `ImportExpression`, `SequenceExpression`, and
   `ThisExpression` for `no-top-level-variables`.
 - (`56d7a83`) Allow top-level `WeakMap` and `WeakSet` in recommended config.
+- (`f751d93`) Disallow shadowing `require` in CommonJS.
 
 ## [3.4.0] - 2024-07-29
 

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -398,15 +398,17 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           return;
         }
 
-        for (const declaration of node.declarations) {
-          if (
-            declaration.id.type === 'Identifier' &&
-            declaration.id.name === 'require'
-          ) {
-            context.report({
-              node: declaration,
-              messageId: disallowedRequireShadow.id
-            });
+        if (options.isCommonjs(node)) {
+          for (const declaration of node.declarations) {
+            if (
+              declaration.id.type === 'Identifier' &&
+              declaration.id.name === 'require'
+            ) {
+              context.report({
+                node: declaration,
+                messageId: disallowedRequireShadow.id
+              });
+            }
           }
         }
       },

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -393,6 +393,23 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           });
         }
       },
+      VariableDeclaration: (node) => {
+        if (!isTopLevel(node)) {
+          return;
+        }
+
+        for (const declaration of node.declarations) {
+          if (
+            declaration.id.type === 'Identifier' &&
+            declaration.id.name === 'require'
+          ) {
+            context.report({
+              node: declaration,
+              messageId: disallowedRequireShadow.id
+            });
+          }
+        }
+      },
       WhileStatement: (node) => {
         if (isTopLevel(node)) {
           context.report({

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -264,7 +264,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
 
         if (options.isCommonjs(node) && node.id.name === 'require') {
           context.report({
-            node: node,
+            node: node.id,
             messageId: disallowedRequireShadow.id
           });
         }
@@ -405,7 +405,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
               declaration.id.name === 'require'
             ) {
               context.report({
-                node: declaration,
+                node: declaration.id,
                 messageId: disallowedRequireShadow.id
               });
             }

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -31,6 +31,10 @@ const disallowedSideEffect = {
   id: '0',
   message: 'Side effects at the top level are not allowed'
 };
+const disallowedRequireShadow = {
+  id: '1',
+  message: 'Shadowing `require` is not allowed'
+};
 
 function isCallTo(expression: CallExpression, name: string): boolean {
   return (
@@ -125,7 +129,8 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
       }
     ],
     messages: {
-      [disallowedSideEffect.id]: disallowedSideEffect.message
+      [disallowedSideEffect.id]: disallowedSideEffect.message,
+      [disallowedRequireShadow.id]: disallowedRequireShadow.message
     }
   },
   create: (context) => {
@@ -249,6 +254,18 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           context.report({
             node,
             messageId: disallowedSideEffect.id
+          });
+        }
+      },
+      FunctionDeclaration: (node) => {
+        if (!isTopLevel(node)) {
+          return;
+        }
+
+        if (options.isCommonjs(node) && node.id.name === 'require') {
+          context.report({
+            node: node,
+            messageId: disallowedRequireShadow.id
           });
         }
       },

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -2610,7 +2610,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
   // A function called require
   ...[
     {
-      code: `function require() {}`,
+      code: `function require() {/* options */}`,
       options: [options.commonjs],
       errors: [
         {
@@ -2618,12 +2618,12 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 22
+          endColumn: 35
         }
       ]
     },
     {
-      code: `function require() {}`,
+      code: `function require() {/* sourceType */}`,
       languageOptions: languageOptions.sourceTypeScript,
       errors: [
         {
@@ -2631,7 +2631,59 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 1,
           endLine: 1,
-          endColumn: 22
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      code: `var require = function() { };`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `var require = function require() { };`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      code: `var require = () => { };`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
+    },
+    {
+      code: `var require = "foobar";`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 23
         }
       ]
     }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -2622,9 +2622,9 @@ const invalid: RuleTester.InvalidTestCase[] = [
         {
           messageId: '1',
           line: 1,
-          column: 1,
+          column: 10,
           endLine: 1,
-          endColumn: 35
+          endColumn: 17
         }
       ]
     },
@@ -2635,9 +2635,9 @@ const invalid: RuleTester.InvalidTestCase[] = [
         {
           messageId: '1',
           line: 1,
-          column: 1,
+          column: 10,
           endLine: 1,
-          endColumn: 38
+          endColumn: 17
         }
       ]
     },
@@ -2650,7 +2650,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 5,
           endLine: 1,
-          endColumn: 29
+          endColumn: 12
         }
       ]
     },
@@ -2663,7 +2663,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 5,
           endLine: 1,
-          endColumn: 37
+          endColumn: 12
         }
       ]
     },
@@ -2676,7 +2676,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 5,
           endLine: 1,
-          endColumn: 24
+          endColumn: 12
         }
       ]
     },
@@ -2689,7 +2689,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 5,
           endLine: 1,
-          endColumn: 23
+          endColumn: 12
         }
       ]
     }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -562,6 +562,12 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `function notRequire() { }`,
       options: [options.commonjs]
+    },
+    {
+      code: `var require = () => { };`
+    },
+    {
+      code: `var require = "foobar";`
     }
   ],
 

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -546,6 +546,25 @@ const valid: RuleTester.ValidTestCase[] = [
     }
   ],
 
+  // A function called require
+  ...[
+    {
+      code: `function require() {}`
+    },
+    {
+      code: `function require() {}`,
+      options: [options.noCommonjs]
+    },
+    {
+      code: `function f() { function require() {} }`,
+      options: [options.commonjs]
+    },
+    {
+      code: `function notRequire() { }`,
+      options: [options.commonjs]
+    }
+  ],
+
   // Derived values
   ...[
     {
@@ -2583,6 +2602,36 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 1,
           endLine: 1,
           endColumn: 31
+        }
+      ]
+    }
+  ],
+
+  // A function called require
+  ...[
+    {
+      code: `function require() {}`,
+      options: [options.commonjs],
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      code: `function require() {}`,
+      languageOptions: languageOptions.sourceTypeScript,
+      errors: [
+        {
+          messageId: '1',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 22
         }
       ]
     }


### PR DESCRIPTION
Closes #1400

## Summary

Prevent code stealthily bypassing the `no-top-level-side-effects` rule by shadowing the `require` function and calling it.