### PR TITLE
Configure Semgrep to run without auth in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -194,6 +194,25 @@ jobs:
           npm pack
       - name: Verify checksum
         run: shasum --check checksums.txt --strict
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # To upload SARIF results
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+      - name: Perform Semgrep analysis
+        run: semgrep --sarif --output semgrep.sarif
+      - name: Upload Semgrep report to GitHub
+        uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: semgrep.sarif
   test:
     name: Test
     runs-on: ubuntu-24.04

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,9 +1,0 @@
-name: Semgrep
-on:
-  push:
-    branches:
-      - main
-
-permissions: read-all
-
-jobs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,24 +7,3 @@ on:
 permissions: read-all
 
 jobs:
-  semgrep:
-    name: Semgrep
-    runs-on: ubuntu-24.04
-    permissions:
-      security-events: write # To upload SARIF results
-    container:
-      image: semgrep/semgrep
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-        with:
-          persist-credentials: false
-      - name: Perform Semgrep analysis
-        run: semgrep ci --sarif --output semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      - name: Upload Semgrep report to GitHub
-        uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
-        if: ${{ failure() || success() }}
-        with:
-          sarif_file: semgrep.sarif


### PR DESCRIPTION
Relates to #313, #486

## Summary

Reconfigure the CI to run Semgrep without auth so that we can run it for all contributions and don't depend on the availability of the Semgrep servers.