### PR TITLE
Optionally allow adding properties to function declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning].
 
 - (`dbbd871`) Add option to disallow top-level property accesses to
   `no-top-level-side-effects`.
+- (`dbbd871`) Add option to allow adding properties to a function declaration at
+  the top-level `no-top-level-side-effects`.
 
 ## [3.4.1] - 2025-03-16
 

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -79,6 +79,8 @@ This rule accepts a configuration object with five options:
 - `allowDerived: false` (default) Configure whether derivations - binary,
   logical, or unary operations on values and variables - are allowed at the top
   level.
+- `allowFunctionProperties: false` (default) Configure whether it is allowed to
+  extend functions with properties.
 - `commonjs` Configure whether the code being analyzed is, or is partially,
   CommonJS code. If not specified it will use ESLint hints to determine if a
   given piece of code is written in CommonJS or not. For CommonJS it allows for
@@ -189,6 +191,26 @@ const u01 = -a;
 const u02 = +a;
 const u03 = !a;
 const u04 = ~a;
+```
+
+#### `allowFunctionProperties`
+
+Examples of **correct** code when `'allowFunctionProperties'` is set to `true`:
+
+```javascript
+function SomeReactComponent() {}
+SomeReactComponent.displayName = 'MyComponent';
+```
+
+Examples of **incorrect** code when `'allowFunctionProperties'` is set to
+`true`:
+
+```javascript
+import {SomeReactComponent} from './SomeReactComponent.jsx';
+SomeReactComponent.displayName = 'SomeReactComponent must be declared locally';
+
+const someObject = {};
+someObject.someProperty = 'someObject must be a function declaration';
 ```
 
 #### `commonjs`

--- a/lib/configs/strict.ts
+++ b/lib/configs/strict.ts
@@ -11,7 +11,7 @@ export const configStrict = {
         allowDerived: false,
         allowedCalls: [],
         allowedNews: [],
-        allowFunctionProperties: true,
+        allowFunctionProperties: false,
         allowIIFE: false,
         allowPropertyAccess: false
       }

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -12,6 +12,7 @@ const options: {
     allowDerived?: boolean;
     allowedCalls?: string[];
     allowedNews?: string[];
+    allowFunctionProperties?: boolean;
     allowIIFE?: boolean;
     commonjs?: boolean;
   };
@@ -24,6 +25,9 @@ const options: {
   },
   allowCallBigInt: {
     allowedCalls: ['BigInt']
+  },
+  allowFunctionProperties: {
+    allowFunctionProperties: true
   },
   allowNoCalls: {
     allowedCalls: []
@@ -852,6 +856,24 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `const arr = [...ok()];`,
       options: [{...options.allowDerived, allowedCalls: ['ok']}]
+    }
+  ],
+
+  // Function property assignment
+  ...[
+    {
+      code: `
+        function SomeReactComponent() {}
+        SomeReactComponent.displayName = 'MyComponent';
+      `,
+      options: [options.allowFunctionProperties]
+    },
+    {
+      code: `
+        function SomeReactComponent() {}
+        SomeReactComponent[foo] = 'bar';
+      `,
+      options: [{...options.allowFunctionProperties, ...options.allowDerived}]
     }
   ]
 ];
@@ -3608,6 +3630,58 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 17,
           endLine: 1,
           endColumn: 22
+        }
+      ]
+    }
+  ],
+
+  // Function property assignment
+  ...[
+    {
+      code: `
+        function ComponentA() {}
+        ComponentB.displayName = 'MyComponent';
+      `,
+      options: [options.allowFunctionProperties],
+      errors: [
+        {
+          messageId: '0',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 48
+        }
+      ]
+    },
+    {
+      code: `
+        function SomeReactComponent() {}
+        SomeReactComponent[foo] = 'bar';
+      `,
+      options: [options.allowFunctionProperties],
+      errors: [
+        {
+          messageId: '0',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 41
+        }
+      ]
+    },
+    {
+      code: `
+        const x = {};
+        x.y = "z";
+      `,
+      options: [options.allowFunctionProperties],
+      errors: [
+        {
+          messageId: '0',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 19
         }
       ]
     }


### PR DESCRIPTION
Closes #1109 

## Summary

Add an option to the [`no-top-level-side-effects` rule](https://github.com/ericcornelissen/eslint-plugin-top/blob/e760ffab5f777ec26665f8f47daba6cc6eeafc2b/docs/rules/no-top-level-side-effects.md) that allows for adding a property to a function declaration. This supports the pattern where a function declaration doubles as an object, as seen in e.g., functional React components. This is necessary because there is no other way for functions to be assigned (static) properties.