### PR TITLE
Optionally disallow property accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`dbbd871`) Add option to disallow top-level property accesses to
+  `no-top-level-side-effects`.
 
 ## [3.4.1] - 2025-03-16
 

--- a/docs/rules/no-top-level-side-effects.md
+++ b/docs/rules/no-top-level-side-effects.md
@@ -79,6 +79,9 @@ This rule accepts a configuration object with five options:
 - `allowDerived: false` (default) Configure whether derivations - binary,
   logical, or unary operations on values and variables - are allowed at the top
   level.
+- `allowPropertyAccess: true` (default) Configure whether accessing a property
+  on an object is allowed. May be disallowed to avoid side effects due to `get`
+  properties.
 - `commonjs` Configure whether the code being analyzed is, or is partially,
   CommonJS code. If not specified it will use ESLint hints to determine if a
   given piece of code is written in CommonJS or not. For CommonJS it allows for
@@ -189,6 +192,15 @@ const u01 = -a;
 const u02 = +a;
 const u03 = !a;
 const u04 = ~a;
+```
+
+#### `allowPropertyAccess`
+
+Examples of **incorrect** code when `'allowPropertyAccess'` is set to `false`:
+
+```javascript
+const foo = bar.baz;
+const {hello} = world;
 ```
 
 #### `commonjs`

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -11,7 +11,8 @@ export const configRecommended = {
         allowedCalls: ['Symbol'],
         allowedNews: ['Map', 'Set', 'WeakMap', 'WeakSet'],
         allowIIFE: false,
-        allowDerived: false
+        allowDerived: false,
+        allowPropertyAccess: true
       }
     ],
     'top/no-top-level-variables': [

--- a/lib/configs/strict.ts
+++ b/lib/configs/strict.ts
@@ -11,7 +11,8 @@ export const configStrict = {
         allowedCalls: [],
         allowedNews: [],
         allowIIFE: false,
-        allowDerived: false
+        allowDerived: false,
+        allowPropertyAccess: false
       }
     ],
     'top/no-top-level-variables': [

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -12,6 +12,7 @@ const options: {
     allowDerived?: boolean;
     allowedCalls?: string[];
     allowedNews?: string[];
+    allowPropertyAccess?: boolean;
     allowIIFE?: boolean;
     commonjs?: boolean;
   };
@@ -36,6 +37,9 @@ const options: {
   },
   commonjs: {
     commonjs: true
+  },
+  disallowPropertyAccess: {
+    allowPropertyAccess: false
   },
   noCommonjs: {
     commonjs: false
@@ -735,6 +739,30 @@ const valid: RuleTester.ValidTestCase[] = [
           const chainExpression = foo?.bar;
         }
       `
+    }
+  ],
+
+  // Property access
+  ...[
+    {
+      code: `const foo = bar.baz;`
+    },
+    {
+      code: `const foo = bar[0];`
+    },
+    {
+      code: `const {foo} = bar;`
+    },
+    {
+      code: `const [foo] = bar;`
+    },
+    {
+      code: `
+        function foo() {
+          return bar.baz;
+        }
+      `,
+      options: [options.disallowPropertyAccess]
     }
   ],
 
@@ -3247,6 +3275,116 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 12,
           endLine: 1,
           endColumn: 15
+        }
+      ]
+    }
+  ],
+
+  // Property access
+  ...[
+    {
+      code: `const foo = bar.baz;`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `const foo = bar[0];`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const {foo} = bar;`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `const [foo] = bar;`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 7,
+          endLine: 1,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `const foo = { bar: hello.world };`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: `const foo = [bar.baz];`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+
+    // MemberExpressions that should be reported only once.
+    {
+      code: `const foo = { bar: console.log("Hello world!") };`,
+      options: [options.disallowPropertyAccess],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 47
+        }
+      ]
+    },
+    {
+      code: `foo.bar = "baz";`,
+      options: [{allowPropertyAccess: false}],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 17
         }
       ]
     }


### PR DESCRIPTION
Closes #1399

## Summary

Add an option to disallow property access at the top level for the `no-top-level-side-effects` rule to protect against `get` properties, which can execute arbitrary JavaScript on being accessed.
