### PR TITLE
Add `malicious-code-ruleset`-based Semgrep scan

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
   malicious-code:
-    name: Malicious Code
+    name: Malicious code
     runs-on: ubuntu-24.04
     container:
       image: semgrep/semgrep

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -129,6 +129,20 @@ jobs:
           languages: ${{ matrix.what }}
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
+  malicious-code:
+    name: Malicious Code
+    runs-on: ubuntu-24.04
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+      - name: Get malicious-code-ruleset
+        run: git clone https://github.com/apiiro/malicious-code-ruleset.git ../malicious-code-ruleset
+      - name: Perform Semgrep analysis
+        run: semgrep --config ../malicious-code-ruleset
   odgen:
     name: ODGen
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Proof of concept of continuously scanning for malicious code in this repo, the goal with this is to prevent malicious contributions. The implementation here is not ideal because we don't have the ruleset pinned. Ideally, this would be addressed in a sustainable way.