### PR TITLE
Add `AUTHORS` file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of eslint-plugin-top's contributors, in alphabetical order.
+#
+# Each line represents a contributor in the format: "Name <email> (url)",
+# where 'Name' may be a pseudonym, and both 'email' and 'url' are optional.
+
+Eric Cornelissen <ericornelissen@gmail.com> (https://ericcornelissen.dev/)
+Damien Erambert <damien@erambert.me>
+Yurui Zhang <yuruiology@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ If you decide to make a contribution, please do use the following workflow:
 - Fork the repository.
 - Create a new branch from the latest `main`.
 - Make your changes on the new branch.
+- Add yourself to the [AUTHORS] list (optional).
 - Commit to the new branch and push the commit(s).
 - Open a Pull Request against `main`.
 
@@ -244,6 +245,7 @@ This will create a directory called `dist` (note that this ignored by git).
 [@eslint/markdown]: https://www.npmjs.com/package/@eslint/markdown
 [@typescript-eslint]: https://typescript-eslint.io/
 [actionlint]: https://github.com/rhysd/actionlint
+[authors]: ./AUTHORS
 [better-npm-audit]: https://www.npmjs.com/package/better-npm-audit
 [bug report]: https://github.com/ericcornelissen/eslint-plugin-top/issues/new?labels=bug
 [depreman]: https://www.npmjs.com/package/depreman


### PR DESCRIPTION
## Summary

Add a file named `AUTHORS` to the project that lists contributors of the project, inspired by [Google Open Source][1]. This aims to provide more transparency on and recognition to those that have contributed and thus have licensing right to the project. Currently, all previous contributors are included and my intention, in contrast to the above, is to include all future contributors too unless contributors themselves do not which to be included.

This file is also supported by npm, using it as a fallback for the manifest's `contributors` field ([docs][2]), which this project does not have (see also #1555).

The list was created based on the output of:

    git log --format='%aN <%aE>' | sort -uf

from which bots were excluded and anonymous GitHub emails removed.

[1]: https://opensource.google/documentation/reference/releasing/authors
[2]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#default-values