### PR TITLE
Support template literals with `allowDerived`

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -15,6 +15,7 @@ const topLevelTypes = [
   'ObjectExpression',
   'Property',
   'SpreadElement',
+  'TemplateLiteral',
   'UnaryExpression',
   'VariableDeclaration',
   'VariableDeclarator'

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -451,6 +451,10 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           return;
         }
 
+        if (options.allowDerived) {
+          return;
+        }
+
         if (isTopLevel(node)) {
           context.report({
             node,

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -718,6 +718,14 @@ const valid: RuleTester.ValidTestCase[] = [
       options: [{...options.allowDerived, allowedCalls: ['ok']}]
     },
     {
+      code: `const s01 = "a" + b;`,
+      options: [options.allowDerived]
+    },
+    {
+      code: `const s02 = \`a\${b}\`;`,
+      options: [options.allowDerived]
+    },
+    {
       code: `
         function f() {
           const binaryExpression = a + b;
@@ -3208,6 +3216,19 @@ const invalid: RuleTester.InvalidTestCase[] = [
           messageId: '0',
           line: 1,
           column: 13,
+          endLine: 1,
+          endColumn: 21
+        }
+      ]
+    },
+    {
+      code: `const foo = \`\${bar()}\`;`,
+      options: [options.allowDerived],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 16,
           endLine: 1,
           endColumn: 21
         }


### PR DESCRIPTION
## Summary

Allow template literals with expressions when [`allowDerived`](https://github.com/ericcornelissen/eslint-plugin-top/blob/0395712d07c15af79945cf26528e48a43faf4ec7/docs/rules/no-top-level-side-effects.md#allowderived) is on, in which case the expressions themselves will be reported if they are side effects.