### PR TITLE
Only `-x` at the top level is allowed (with `allowDerived`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning].
 
 - ([#1565]) Allow template literals when `allowDerived` is set to true for the
   `no-top-level-side-effects` rule.
+- ([#1568]) Restrict unary operators to negative numbers when `allowDerived` for
+  the `no-top-level-side-effects` rule.
 
 ## [3.5.3] - 2025-06-17
 
@@ -228,3 +230,4 @@ Versioning].
 [#1475]: https://github.com/ericcornelissen/eslint-plugin-top/pull/1475
 [#1506]: https://github.com/ericcornelissen/eslint-plugin-top/pull/1506
 [#1565]: https://github.com/ericcornelissen/eslint-plugin-top/pull/1565
+[#1568]: https://github.com/ericcornelissen/eslint-plugin-top/pull/1568

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -479,7 +479,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
         }
       },
       UnaryExpression: (node) => {
-        if (node.argument.type === 'Literal') {
+        if (node.operator === '-' && node.argument.type === 'Literal') {
           return;
         }
 

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -3145,7 +3145,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 13,
           endLine: 1,
-          endColumn: 19
+          endColumn: 18
         }
       ]
     },
@@ -3169,7 +3169,7 @@ const invalid: RuleTester.InvalidTestCase[] = [
           line: 1,
           column: 13,
           endLine: 1,
-          endColumn: 19
+          endColumn: 16
         }
       ]
     },

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -3138,6 +3138,42 @@ const invalid: RuleTester.InvalidTestCase[] = [
       ]
     },
     {
+      code: `const u05 = +3.14;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const u06 = !false;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `const u07 = ~42;`,
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
+    },
+    {
       code: `const foo = 1 + 2;`,
       errors: [
         {


### PR DESCRIPTION
## Summary

Only minus should be allowed to be able to have a negative number at the top level, the others are (I believe) not necessary. If you disagree, open an issue and give a reason why the unary operator is necessary at the top level.