### PR TITLE
Configure Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: daily
       time: '05:00'
+    cooldown:
+      default-days: 2
     labels:
       - dependencies
     groups:
@@ -23,6 +25,8 @@ updates:
     schedule:
       interval: daily
       time: '05:00'
+    cooldown:
+      default-days: 2
     labels:
       - ci
       - dependencies


### PR DESCRIPTION
## Summary

Update the Dependabot configuration to use a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) period for dependency updates. This is primarily to test the feature. I see two potential benefits:

1. Avoid upgrading to a malicious version of a dependency, because hopefully the incident is discovered before the cooldown period ends.
2. Avoid receiving separate PRs for patch updates created in ~quick succession, though based on the description of the option I'm not sure this would actually turn out to work very well.