### PR TITLE
Refactor `no-top-level-side-effects` for readability

### DIFF
--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -365,11 +365,11 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
         }
       },
       FunctionDeclaration: (node) => {
-        if (
-          node.id?.name === 'require' &&
-          isTopLevel(node) &&
-          options.isCommonjs(node)
-        ) {
+        if (!isTopLevel(node)) {
+          return;
+        }
+
+        if (node.id?.name === 'require' && options.isCommonjs(node)) {
           context.report({
             node: node.id,
             messageId: disallowedRequireShadow.id

--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -375,7 +375,7 @@ export const noTopLevelSideEffects: Rule.RuleModule = {
           return;
         }
 
-        if (node.id?.name === 'require' && options.isCommonjs(node)) {
+        if (node.id.name === 'require' && options.isCommonjs(node)) {
           context.report({
             node: node.id,
             messageId: disallowedRequireShadow.id


### PR DESCRIPTION
Continuation of #1566