### PR TITLE
Refactor all rules

### DIFF
--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -158,6 +158,42 @@ const valid: RuleTester.ValidTestCase[] = [
           }
         }
       `
+    },
+    {
+      code: `
+        function foobar() {
+          var a = 1;
+          var b = 3.14;
+          var c = 42n;
+          var d = 'Hello';
+          var e = "world";
+          var f = \`!\`;
+          var g = \`\${d} \${e}\${f}\`;
+          var h = {};
+          var i = [];
+          var j = h.p;
+          var k = h[p];
+          var l = i[0];
+          var m = { q: "answer" };
+          var n = [2, 7, 1];
+          var o = { [d]: e };
+          var p = [a, b, c];
+          var { q } = m;
+          var [r] = n;
+          var s = $\`foobar\`;
+        }
+      `
+    },
+    {
+      code: `
+        function foobar() {
+          const binary = a + b;
+          const chain = foo?.bar;
+          const conditional = foo ? bar : baz;
+          const logical = a || b;
+          const unary = -a;
+        }
+      `
     }
   ],
 
@@ -250,31 +286,6 @@ const valid: RuleTester.ValidTestCase[] = [
     },
     {
       code: `const [ a1, a2 ] = a;`
-    },
-    {
-      code: `
-        function foobar() {
-          var a = 1;
-          var b = 3.14;
-          var c = 42n;
-          var d = 'Hello';
-          var e = "world";
-          var f = \`!\`;
-          var g = \`\${d} \${e}\${f}\`;
-          var h = {};
-          var i = [];
-          var j = h.p;
-          var k = h[p];
-          var l = i[0];
-          var m = { q: "answer" };
-          var n = [2, 7, 1];
-          var o = { [d]: e };
-          var p = [a, b, c];
-          var { q } = m;
-          var [r] = n;
-          var s = $\`foobar\`;
-        }
-      `
     }
   ].flatMap((tc) => [
     tc,
@@ -783,41 +794,6 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `const s02 = \`a\${b}\`;`,
       options: [options.allowDerived]
-    },
-    {
-      code: `
-        function f() {
-          const binaryExpression = a + b;
-        }
-      `
-    },
-    {
-      code: `
-        function f() {
-          const logicalExpression = a || b;
-        }
-      `
-    },
-    {
-      code: `
-        function f() {
-          const conditionalExpression = foo ? bar : baz;
-        }
-      `
-    },
-    {
-      code: `
-        function f() {
-          const unaryExpression = -a;
-        }
-      `
-    },
-    {
-      code: `
-        function f() {
-          const chainExpression = foo?.bar;
-        }
-      `
     }
   ],
 

--- a/tests/unit/no-top-level-variables.test.ts
+++ b/tests/unit/no-top-level-variables.test.ts
@@ -60,6 +60,22 @@ const valid: RuleTester.ValidTestCase[] = [
           const foo = 'bar';
         }
       `
+    },
+    {
+      code: `
+        function fArray() {
+          const arr1 = [];
+          const arr2 = ["b", "a", "r"];
+        }
+      `
+    },
+    {
+      code: `
+        function fObject() {
+          const obj1 = {};
+          const obj2 = { bar: "baz" };
+        }
+      `
     }
   ],
 
@@ -472,6 +488,36 @@ const invalid: RuleTester.InvalidTestCase[] = [
           column: 1,
           endLine: 1,
           endColumn: 25
+        }
+      ]
+    },
+    {
+      code: `
+        var uninitialized;
+      `,
+      options: [options.kindVar],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 18
+        }
+      ]
+    },
+    {
+      code: `
+        let uninitialized;
+      `,
+      options: [options.kindLet],
+      errors: [
+        {
+          messageId: '0',
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 18
         }
       ]
     }


### PR DESCRIPTION
Relates to #1566, #1583

## Summary

- Flatten function-level control flow (main path is unindented).
- Simplify if-guards.
- Extract one more function.
- Heuristically order allowed cases by increasing runtime cost.
- Also use `VariableDeclarator` in `no-top-level-variables` implementation.
- Regroup test cases.
- Add missing test cases