### PR TITLE
Ignore GHSA-52f5-9888-hmc6

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,6 @@
 {
+  "GHSA-52f5-9888-hmc6": {
+    "active": true,
+    "notes": "This affects development dependencies where it is not exploitable. Resolution in progress."
+  }
 }


### PR DESCRIPTION
Closes #1591

## Summary

Ignore GHSA-52f5-9888-hmc6 because it has no impact on this project and the resolution is being tracked upstream (see #1591 for details).