### PR TITLE
Avoid updating transitive dependencies too recently

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
       - name: Update dependencies
-        run: npm update --prefer-dedupe
+        run: |
+          npm update \
+            --prefer-dedupe \
+            --before "$( date -u -d "@$(($(date +%s) - 2*24*60*60))" +"%Y-%m-%d" )"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:


### PR DESCRIPTION
Relates to  #1557

## Summary

... in order to avoid being affected by malicious updates (imperfect solution). The delay is set to 2 days (`2*24*60*60`), so we'll only upgrade to version released at least 48 hours ago from when the workflow runs.