### PR TITLE
Attempt to fix vulnerable dependencies when detected

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -16,15 +16,9 @@ on:
 permissions: read-all
 
 jobs:
-  audit:
-    name: ${{ matrix.what }}
+  deprecations:
+    name: Deprecations
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        what:
-          - deprecations
-          - vulnerabilities
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -37,7 +31,43 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm clean-install
-      - name: Audit
-        run: npm run "audit:${WHAT}"
-        env:
-          WHAT: ${{ matrix.what }}
+      - name: Audit for deprecation warnings
+        run: npm run audit:deprecations
+  vulnerabilities:
+    name: vulnerabilities
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Audit for vulnerabilities
+        run: npm run audit:vulnerabilities
+      - name: Bump vulnerable dependencies
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        run: npm audit fix
+      - name: Create automation token
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+      - name: Create Pull Request
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+        with:
+          token: ${{ steps.automation-token.outputs.token }}
+          title: Update vulnerable dependencies
+          body: |
+            _This Pull Request was created automatically based on at least one
+            known vulnerability detected in CI._
+          branch: bump-vulnerable-dependencies
+          commit-message: Fix vulnerable dependencies with `npm audit fix`


### PR DESCRIPTION
Relates to 0f80dc508e734428965a0dadf778ad4396282342, #1306

## Summary

Extend the `audit-dev.yml` job "Vulnerabilities" to try and fix the vulnerabilities with `npm audit fix` and submit a PR for the changes if any vulnerabilities are detected on a schedule (we don't want this for non-schedule jobs because it would get messy, e.g. creating PRs to merge the fix into (unrelated) development branches).