### PR TITLE
Update `.nsprc`

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -18,5 +18,15 @@
     "active": true,
     "expiry": "2027-01-01",
     "notes": "Pending https://github.com/microsoft/typed-rest-client/issues/400"
+  },
+  "GHSA-h67p-54hq-rp68": {
+    "active": true,
+    "expiry": "2027-01-01",
+    "notes": "Pending https://github.com/yarnpkg/berry/issues/7186 and https://github.com/igorshubovych/markdownlint-cli/issues/629"
+  },
+  "GHSA-6v5v-wf23-fmfq": {
+    "active": true,
+    "expiry": "2027-01-01",
+    "notes": "Pending https://github.com/igorshubovych/markdownlint-cli/issues/629"
   }
 }


### PR DESCRIPTION
Caused by GHSA-h67p-54hq-rp68, GHSA-6v5v-wf23-fmfq
Relates to [Audit job #2030](https://github.com/ericcornelissen/eslint-plugin-top/actions/runs/27605117310), https://github.com/ericcornelissen/shescape/pull/2583
See also https://github.com/igorshubovych/markdownlint-cli/issues/629 and https://github.com/yarnpkg/berry/issues/7186

