### PR TITLE
Don't report `var { require: foo } = { require: "bar" }`

### DIFF
--- a/lib/rules/no-top-level-side-effects.ts
+++ b/lib/rules/no-top-level-side-effects.ts
@@ -167,9 +167,6 @@ function isShadowingRequire(node: VariableDeclarator): boolean {
       for (const property of node.id.properties) {
         if (
           (property.type === 'Property' &&
-            property.key.type === 'Identifier' &&
-            property.key.name === 'require') ||
-          (property.type === 'Property' &&
             property.value.type === 'Identifier' &&
             property.value.name === 'require') ||
           (property.type === 'RestElement' &&

--- a/tests/unit/no-top-level-side-effects.test.ts
+++ b/tests/unit/no-top-level-side-effects.test.ts
@@ -706,6 +706,10 @@ const valid: RuleTester.ValidTestCase[] = [
     {
       code: `function notRequire() { }`,
       options: [options.commonjs]
+    },
+    {
+      code: `var { require: foo } = { require: "bar" };`,
+      options: [options.commonjs]
     }
   ],
 


### PR DESCRIPTION
Closes #1960